### PR TITLE
[Hotfix] RestDocs 누락된 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ java {
 }
 
 configurations {
+	asciidoctorExt
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -44,7 +45,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
@@ -55,7 +56,15 @@ tasks.named('test') {
 
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
+	configurations 'asciidoctorExt'
 	dependsOn test
+}
+
+bootJar { // jar의 templates에 문서 복사
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}") {
+		into 'BOOT-INF/classes/templates'
+	}
 }
 
 spotless {


### PR DESCRIPTION
## 이슈 번호 (#22)

## 요약
asciidoctor 관련 설정이 누락되어 RestDocs가 제대로 동작하지 않음, 해결

## 변경사항 (`build.gradle`)
https://docs.spring.io/spring-restdocs/docs/current/reference/htmlsingle/
- configurations에 `asciidoctorExt` 추가
- bootJar task에 패키징 코드 추가


