### PR TITLE
[Fix] 월 목표 조회 조건에 deleted 컬럼 포함

### DIFF
--- a/src/main/java/com/sillim/recordit/goal/domain/MonthlyGoal.java
+++ b/src/main/java/com/sillim/recordit/goal/domain/MonthlyGoal.java
@@ -46,7 +46,7 @@ public class MonthlyGoal extends BaseTime {
 	@ColumnDefault("false")
 	private Boolean achieved;
 
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
 

--- a/src/main/java/com/sillim/recordit/goal/domain/MonthlyGoal.java
+++ b/src/main/java/com/sillim/recordit/goal/domain/MonthlyGoal.java
@@ -9,14 +9,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SoftDelete;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SoftDelete
 public class MonthlyGoal extends BaseTime {
 
 	@Id
@@ -43,11 +46,7 @@ public class MonthlyGoal extends BaseTime {
 	@ColumnDefault("false")
 	private Boolean achieved;
 
-	@Column(nullable = false)
-	@ColumnDefault("false")
-	private Boolean deleted;
-
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "member_id")
 	private Member member;
 
@@ -64,8 +63,7 @@ public class MonthlyGoal extends BaseTime {
 		this.goalYear = goalYear;
 		this.goalMonth = goalMonth;
 		this.colorHex = colorHex;
-		this.achieved = false;
-		this.deleted = false;
+		this.achieved = Boolean.FALSE;
 		this.member = member;
 	}
 

--- a/src/test/java/com/sillim/recordit/goal/controller/dto/request/MonthlyUpdateRequestTest.java
+++ b/src/test/java/com/sillim/recordit/goal/controller/dto/request/MonthlyUpdateRequestTest.java
@@ -26,8 +26,7 @@ public class MonthlyUpdateRequestTest {
 					assertThat(monthlyGoal.getGoalYear()).isEqualTo(request.goalYear());
 					assertThat(monthlyGoal.getGoalMonth()).isEqualTo(request.goalMonth());
 					assertThat(monthlyGoal.getColorHex()).isEqualTo(request.colorHex());
-					assertThat(monthlyGoal.getAchieved()).isEqualTo(false);
-					assertThat(monthlyGoal.getDeleted()).isEqualTo(false);
+					assertThat(monthlyGoal.getAchieved()).isEqualTo(Boolean.FALSE);
 					assertThat(monthlyGoal.getMember()).isEqualTo(member);
 				});
 	}


### PR DESCRIPTION
## 이슈 번호 (#38)

## 요약
`MonthlyGoal` 엔티티에 `@SoftDelete` 적용

## 변경 내용

### Hibernate 편리기능을 사용한 soft delete

**방법1: `@SQLDelete`, `SQLRestriction` 어노테이션 사용**
- 삭제 및 조회 시 자동으로 `deleted` 컬럼을 사용하도록 설정

**방법2: `@SoftDelete` 어노테이션 사용**
- `deleted` 컬럼 생성과 위의 설정을 모두 함축해놓은 어노테이션

### 편리기능을 사용할 것인가?

soft-delete된 데이터여도 애플리케이션에서 충분히 다룰 수 있는 여지가 있기 때문에 직접 `where`을 적는 것이 좋다는 의견  
[레퍼런스](https://www.inflearn.com/questions/1197298/sqlrestriction%EC%9C%BC%EB%A1%9C-%EB%85%BC%EB%A6%AC%EC%A0%81-%EC%82%AD%EC%A0%9C-%ED%95%84%EB%93%9C%EC%97%90-%EB%8C%80%ED%95%9C-teardown%EC%97%90-%EB%8C%80%ED%95%B4-%EA%B6%81%EA%B8%88%ED%95%A9%EB%8B%88%EB%8B%A4)
VS

휴먼에러 방지를 위해 편리기능을 사용하는 것이 좋을 것이라는 의견  
