### PR TITLE
🚑️ hotfix[#102]: Schedule에서 Calendar 조회 시 컨텍스트 외부 조회 에러 문제 해결

### DIFF
--- a/src/main/java/com/sillim/recordit/schedule/repository/CustomScheduleRepositoryImpl.java
+++ b/src/main/java/com/sillim/recordit/schedule/repository/CustomScheduleRepositoryImpl.java
@@ -33,6 +33,8 @@ public class CustomScheduleRepositoryImpl extends QuerydslRepositorySupport
 				.where(schedule.calendar.id.eq(calendarId))
 				.where(schedule.scheduleDuration.startDatetime.loe(date.atStartOfDay()))
 				.where(schedule.scheduleDuration.endDatetime.goe(date.atStartOfDay()))
+				.leftJoin(schedule.calendar)
+				.fetchJoin()
 				.leftJoin(schedule.scheduleGroup)
 				.fetchJoin()
 				.leftJoin(schedule.scheduleGroup.repetitionPattern)


### PR DESCRIPTION
## 이슈 번호 (#102 )

## 요약
Schedule에서 Calendar 조회 시 컨텍스트 외부 조회 에러 문제 해결

## 변경 내용

