### PR TITLE
Fix 114: 할 일 도메인 API 연동 중 발생한 오류 수정, 테스트 코드 리팩토링

### DIFF
--- a/src/main/java/com/sillim/recordit/goal/service/MonthlyGoalQueryService.java
+++ b/src/main/java/com/sillim/recordit/goal/service/MonthlyGoalQueryService.java
@@ -6,7 +6,7 @@ import com.sillim.recordit.global.exception.goal.InvalidMonthlyGoalException;
 import com.sillim.recordit.goal.domain.MonthlyGoal;
 import com.sillim.recordit.goal.repository.MonthlyGoalRepository;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,12 +39,18 @@ public class MonthlyGoalQueryService {
 		return monthlyGoalRepository.findMonthlyGoalInMonth(year, month, memberId);
 	}
 
-	public MonthlyGoal searchByIdOrElseNull(final Long monthlyGoalId, final Long memberId) {
+	public Optional<MonthlyGoal> searchOptionalById(final Long monthlyGoalId, final Long memberId) {
 
-		final MonthlyGoal monthlyGoal = monthlyGoalRepository.findById(monthlyGoalId).orElse(null);
-		if (Objects.nonNull(monthlyGoal) && !monthlyGoal.isOwnedBy(memberId)) {
-			throw new InvalidMonthlyGoalException(ErrorCode.MONTHLY_GOAL_ACCESS_DENIED);
+		if (monthlyGoalId == null) {
+			return Optional.empty();
 		}
+		final Optional<MonthlyGoal> monthlyGoal = monthlyGoalRepository.findById(monthlyGoalId);
+		monthlyGoal.ifPresent(
+				mg -> {
+					if (!mg.isOwnedBy(memberId)) {
+						throw new InvalidMonthlyGoalException(ErrorCode.MONTHLY_GOAL_ACCESS_DENIED);
+					}
+				});
 		return monthlyGoal;
 	}
 }

--- a/src/main/java/com/sillim/recordit/task/domain/repetition/TaskMonthlyRepetitionPattern.java
+++ b/src/main/java/com/sillim/recordit/task/domain/repetition/TaskMonthlyRepetitionPattern.java
@@ -177,8 +177,8 @@ public class TaskMonthlyRepetitionPattern extends TaskRepetitionPattern {
 						date -> date.isBefore(getRepetitionEndDate().plusDays(1L)),
 						date ->
 								DateTimeUtils.correctDayOfMonth(
-										date.plusMonths(getRepetitionPeriod()), getDayOfMonth()))
-				.filter(date -> date.getDayOfMonth() == getDayOfMonth())
+										date.plusMonths(getRepetitionPeriod()), dayOfMonth()))
+				.filter(date -> date.getDayOfMonth() == dayOfMonth())
 				.map(
 						date ->
 								Period.ofDays(
@@ -224,21 +224,45 @@ public class TaskMonthlyRepetitionPattern extends TaskRepetitionPattern {
 
 	private boolean hasWeekNumber(final LocalDate date) {
 		LocalDate firstDayOfMonth = date.withDayOfMonth(1);
-		LocalDate firstWeekday = firstDayOfMonth.with(DayOfWeek.of(getWeekday()));
+		LocalDate firstWeekday = firstDayOfMonth.with(DayOfWeek.of(weekday()));
 		if (firstWeekday.isBefore(firstDayOfMonth)) {
 			firstWeekday = firstWeekday.plusWeeks(1);
 		}
-		LocalDate targetWeekday = firstWeekday.plusWeeks(getWeekNumber() - 1);
+		LocalDate targetWeekday = firstWeekday.plusWeeks(weekNumber() - 1);
 		// targetWeekday가 당월을 넘지 않는다면 true 반환 (n번째 m요일이 존재한다.)
 		return targetWeekday.isBefore(date.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1L));
 	}
 
 	private LocalDate findDateByWeekday(final LocalDate date) {
 		LocalDate firstDayOfMonth = date.withDayOfMonth(1);
-		LocalDate firstWeekday = firstDayOfMonth.with(DayOfWeek.of(getWeekday()));
+		LocalDate firstWeekday = firstDayOfMonth.with(DayOfWeek.of(weekday()));
 		if (firstWeekday.isBefore(firstDayOfMonth)) {
 			firstWeekday = firstWeekday.plusWeeks(1);
 		}
-		return firstWeekday.plusWeeks(getWeekNumber() - 1);
+		return firstWeekday.plusWeeks(weekNumber() - 1);
+	}
+
+	private Integer dayOfMonth() {
+		return getDayOfMonth()
+				.orElseThrow(
+						() -> new InvalidRepetitionException(ErrorCode.NULL_TASK_DAY_OF_MONTH));
+	}
+
+	private Integer weekday() {
+		return getWeekday()
+				.map(Weekday::getValue)
+				.orElseThrow(
+						() ->
+								new InvalidRepetitionException(
+										ErrorCode.NULL_TASK_REPETITION_WEEKDAY));
+	}
+
+	private Integer weekNumber() {
+		return getWeekNumber()
+				.map(WeekNumber::getValue)
+				.orElseThrow(
+						() ->
+								new InvalidRepetitionException(
+										ErrorCode.NULL_TASK_REPETITION_WEEKDAY));
 	}
 }

--- a/src/main/java/com/sillim/recordit/task/domain/repetition/TaskRepetitionPattern.java
+++ b/src/main/java/com/sillim/recordit/task/domain/repetition/TaskRepetitionPattern.java
@@ -114,39 +114,33 @@ public abstract class TaskRepetitionPattern extends BaseTime {
 		this.taskGroup = taskGroup;
 	}
 
-	public Integer getMonthOfYear() {
-		if (Optional.ofNullable(monthOfYear).isEmpty()) {
-			return null;
+	public Optional<Integer> getMonthOfYear() {
+		if (monthOfYear == null) {
+			return Optional.empty();
 		}
-		return monthOfYear.getMonthOfYear();
+		return Optional.of(monthOfYear.getMonthOfYear());
 	}
 
-	public Integer getDayOfMonth() {
-		if (Optional.ofNullable(dayOfMonth).isEmpty()) {
-			return null;
+	public Optional<Integer> getDayOfMonth() {
+		if (dayOfMonth == null) {
+			return Optional.empty();
 		}
-		return dayOfMonth.getDayOfMonth();
+		return Optional.of(dayOfMonth.getDayOfMonth());
 	}
 
-	public Integer getWeekNumber() {
-		if (Optional.ofNullable(weekNumber).isEmpty()) {
-			return null;
-		}
-		return weekNumber.getValue();
+	public Optional<WeekNumber> getWeekNumber() {
+		return Optional.ofNullable(weekNumber);
 	}
 
-	public Integer getWeekday() {
-		if (Optional.ofNullable(weekday).isEmpty()) {
-			return null;
-		}
-		return weekday.getValue();
+	public Optional<Weekday> getWeekday() {
+		return Optional.ofNullable(weekday);
 	}
 
-	public Integer getWeekdayBit() {
-		if (Optional.ofNullable(weekdayBit).isEmpty()) {
-			return null;
+	public Optional<Integer> getWeekdayBit() {
+		if (weekdayBit == null) {
+			return Optional.empty();
 		}
-		return weekdayBit.getWeekdayBit();
+		return Optional.ofNullable(weekdayBit.getWeekdayBit());
 	}
 
 	public boolean isValidWeekday(final DayOfWeek dayOfWeek) {

--- a/src/main/java/com/sillim/recordit/task/domain/repetition/TaskYearlyRepetitionPattern.java
+++ b/src/main/java/com/sillim/recordit/task/domain/repetition/TaskYearlyRepetitionPattern.java
@@ -193,8 +193,8 @@ public class TaskYearlyRepetitionPattern extends TaskRepetitionPattern {
 						date -> date.isBefore(getRepetitionEndDate().plusDays(1L)),
 						date ->
 								DateTimeUtils.correctDayOfMonth(
-										date.plusYears(getRepetitionPeriod()), getDayOfMonth()))
-				.filter(date -> date.getDayOfMonth() == getDayOfMonth())
+										date.plusYears(getRepetitionPeriod()), dayOfMonth()))
+				.filter(date -> date.getDayOfMonth() == dayOfMonth())
 				.map(
 						date ->
 								Period.ofDays(
@@ -244,22 +244,46 @@ public class TaskYearlyRepetitionPattern extends TaskRepetitionPattern {
 	private boolean hasWeekNumber(final LocalDate date) {
 
 		LocalDate firstDayOfMonth = date.withDayOfMonth(1);
-		LocalDate firstWeekday = firstDayOfMonth.with(DayOfWeek.of(getWeekday()));
+		LocalDate firstWeekday = firstDayOfMonth.with(DayOfWeek.of(weekday()));
 
 		if (firstWeekday.isBefore(firstDayOfMonth)) {
 			firstWeekday = firstWeekday.plusWeeks(1);
 		}
-		LocalDate targetWeekday = firstWeekday.plusWeeks(getWeekNumber() - 1);
+		LocalDate targetWeekday = firstWeekday.plusWeeks(weekNumber() - 1);
 
 		return targetWeekday.isBefore(date.with(TemporalAdjusters.lastDayOfMonth()).plusDays(1L));
 	}
 
 	private LocalDate findDateByWeekday(final LocalDate date) {
 		LocalDate firstDayOfMonth = date.withDayOfMonth(1);
-		LocalDate firstWeekday = firstDayOfMonth.with(DayOfWeek.of(getWeekday()));
+		LocalDate firstWeekday = firstDayOfMonth.with(DayOfWeek.of(weekday()));
 		if (firstWeekday.isBefore(firstDayOfMonth)) {
 			firstWeekday = firstWeekday.plusWeeks(1);
 		}
-		return firstWeekday.plusWeeks(getWeekNumber() - 1);
+		return firstWeekday.plusWeeks(weekNumber() - 1);
+	}
+
+	private Integer dayOfMonth() {
+		return getDayOfMonth()
+				.orElseThrow(
+						() -> new InvalidRepetitionException(ErrorCode.NULL_TASK_DAY_OF_MONTH));
+	}
+
+	private Integer weekday() {
+		return getWeekday()
+				.map(Weekday::getValue)
+				.orElseThrow(
+						() ->
+								new InvalidRepetitionException(
+										ErrorCode.NULL_TASK_REPETITION_WEEKDAY));
+	}
+
+	private Integer weekNumber() {
+		return getWeekNumber()
+				.map(WeekNumber::getValue)
+				.orElseThrow(
+						() ->
+								new InvalidRepetitionException(
+										ErrorCode.NULL_TASK_REPETITION_WEEKDAY));
 	}
 }

--- a/src/main/java/com/sillim/recordit/task/dto/response/TaskRepetitionDetailsResponse.java
+++ b/src/main/java/com/sillim/recordit/task/dto/response/TaskRepetitionDetailsResponse.java
@@ -1,5 +1,7 @@
 package com.sillim.recordit.task.dto.response;
 
+import com.sillim.recordit.enums.date.WeekNumber;
+import com.sillim.recordit.enums.date.Weekday;
 import com.sillim.recordit.task.domain.TaskRepetitionType;
 import com.sillim.recordit.task.domain.repetition.TaskRepetitionPattern;
 import java.time.LocalDate;
@@ -24,11 +26,12 @@ public record TaskRepetitionDetailsResponse(
 				.repetitionPeriod(repetitionPattern.getRepetitionPeriod())
 				.repetitionStartDate(repetitionPattern.getRepetitionStartDate())
 				.repetitionEndDate(repetitionPattern.getRepetitionEndDate())
-				.monthOfYear(repetitionPattern.getMonthOfYear())
-				.dayOfMonth(repetitionPattern.getDayOfMonth())
-				.weekNumber(repetitionPattern.getWeekNumber())
-				.weekday(repetitionPattern.getWeekday())
-				.weekdayBit(repetitionPattern.getWeekdayBit())
+				.monthOfYear(repetitionPattern.getMonthOfYear().orElse(null))
+				.dayOfMonth(repetitionPattern.getDayOfMonth().orElse(null))
+				.weekNumber(
+						repetitionPattern.getWeekNumber().map(WeekNumber::getValue).orElse(null))
+				.weekday(repetitionPattern.getWeekday().map(Weekday::getValue).orElse(null))
+				.weekdayBit(repetitionPattern.getWeekdayBit().orElse(null))
 				.build();
 	}
 }

--- a/src/main/java/com/sillim/recordit/task/service/TaskGroupService.java
+++ b/src/main/java/com/sillim/recordit/task/service/TaskGroupService.java
@@ -25,9 +25,11 @@ public class TaskGroupService {
 			final Long relatedMonthlyGoalId,
 			final Long relatedWeeklyGoalId,
 			final Long memberId) {
-		final MonthlyGoal monthlyGoal =
-				monthlyGoalQueryService.searchByIdOrElseNull(relatedMonthlyGoalId, memberId);
-		final WeeklyGoal weeklyGoal = null;
+		MonthlyGoal monthlyGoal =
+				monthlyGoalQueryService
+						.searchOptionalById(relatedMonthlyGoalId, memberId)
+						.orElse(null);
+		WeeklyGoal weeklyGoal = null;
 		return taskGroupRepository.save(new TaskGroup(isRepeated, monthlyGoal, weeklyGoal));
 	}
 }

--- a/src/test/java/com/sillim/recordit/goal/service/MonthlyGoalUpdateServiceTest.java
+++ b/src/test/java/com/sillim/recordit/goal/service/MonthlyGoalUpdateServiceTest.java
@@ -1,6 +1,7 @@
 package com.sillim.recordit.goal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -53,7 +54,6 @@ public class MonthlyGoalUpdateServiceTest {
 
 		monthlyGoalUpdateService.add(request, memberId);
 
-		then(memberQueryService).should(times(1)).findByMemberId(eq(memberId));
 		then(monthlyGoalRepository).should(times(1)).save(any(MonthlyGoal.class));
 	}
 
@@ -75,7 +75,14 @@ public class MonthlyGoalUpdateServiceTest {
 
 		monthlyGoalUpdateService.modify(request, monthlyGoalId, memberId);
 
-		then(monthlyGoalQueryService).should(times(1)).searchById(eq(monthlyGoalId), eq(memberId));
+		assertAll(
+				() -> {
+					assertThat(monthlyGoal.getTitle()).isEqualTo(request.title());
+					assertThat(monthlyGoal.getDescription()).isEqualTo(request.description());
+					assertThat(monthlyGoal.getStartDate()).isEqualTo(request.startDate());
+					assertThat(monthlyGoal.getEndDate()).isEqualTo(request.endDate());
+					assertThat(monthlyGoal.getColorHex()).isEqualTo(request.colorHex());
+				});
 	}
 
 	@Test
@@ -90,7 +97,6 @@ public class MonthlyGoalUpdateServiceTest {
 
 		monthlyGoalUpdateService.changeAchieveStatus(monthlyGoalId, status, memberId);
 
-		then(monthlyGoalQueryService).should(times(1)).searchById(eq(monthlyGoalId), eq(memberId));
 		assertThat(monthlyGoal.isAchieved()).isTrue();
 	}
 
@@ -105,7 +111,6 @@ public class MonthlyGoalUpdateServiceTest {
 
 		monthlyGoalUpdateService.remove(monthlyGoalId, memberId);
 
-		then(monthlyGoalQueryService).should(times(1)).searchById(eq(monthlyGoalId), eq(memberId));
 		then(monthlyGoalRepository).should(times(1)).delete(eq(monthlyGoal));
 	}
 }

--- a/src/test/java/com/sillim/recordit/task/service/TaskCommandServiceTest.java
+++ b/src/test/java/com/sillim/recordit/task/service/TaskCommandServiceTest.java
@@ -70,8 +70,6 @@ class TaskCommandServiceTest {
 
 		taskCommandService.addTasks(request, calendarId, memberId);
 
-		then(taskGroupService).should(times(1)).addTaskGroup(eq(false), any(), any(), eq(memberId));
-		then(calendarService).should(times(1)).searchByCalendarId(eq(calendarId), eq(memberId));
 		then(taskRepository).should(times(1)).save(any(Task.class));
 	}
 
@@ -115,11 +113,6 @@ class TaskCommandServiceTest {
 
 		taskCommandService.addTasks(request, calendarId, memberId);
 
-		then(taskGroupService).should(times(1)).addTaskGroup(eq(true), any(), any(), eq(memberId));
-		then(calendarService).should(times(1)).searchByCalendarId(eq(calendarId), eq(memberId));
-		then(repetitionPatternService)
-				.should(times(1))
-				.addRepetitionPattern(eq(request.repetition()), eq(taskGroup));
 		then(taskRepository).should(times(91)).save(any(Task.class));
 	}
 }

--- a/src/test/java/com/sillim/recordit/task/service/TaskGroupServiceTest.java
+++ b/src/test/java/com/sillim/recordit/task/service/TaskGroupServiceTest.java
@@ -13,6 +13,7 @@ import com.sillim.recordit.goal.service.MonthlyGoalQueryService;
 import com.sillim.recordit.member.fixture.MemberFixture;
 import com.sillim.recordit.task.domain.TaskGroup;
 import com.sillim.recordit.task.repository.TaskGroupRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +35,8 @@ class TaskGroupServiceTest {
 	void addTaskGroupTest() {
 		Long memberId = 1L;
 		TaskGroup expected = new TaskGroup(false, null, null);
-		given(monthlyGoalQueryService.searchByIdOrElseNull(any(), eq(memberId))).willReturn(null);
+		given(monthlyGoalQueryService.searchOptionalById(any(), eq(memberId)))
+				.willReturn(Optional.empty());
 		given(taskGroupRepository.save(any(TaskGroup.class))).willReturn(expected);
 
 		TaskGroup saved = taskGroupService.addTaskGroup(false, null, null, memberId);
@@ -43,7 +45,6 @@ class TaskGroupServiceTest {
 				.usingRecursiveComparison()
 				.ignoringFields("id", "createdAt", "modifiedAt")
 				.isEqualTo(expected);
-		then(monthlyGoalQueryService).should(times(1)).searchByIdOrElseNull(any(), eq(memberId));
 		then(taskGroupRepository).should(times(1)).save(any(TaskGroup.class));
 	}
 
@@ -56,8 +57,8 @@ class TaskGroupServiceTest {
 				MonthlyGoalFixture.DEFAULT.getWithMember(MemberFixture.DEFAULT.getMember());
 		TaskGroup expected = new TaskGroup(false, monthlyGoal, null);
 
-		given(monthlyGoalQueryService.searchByIdOrElseNull(eq(relatedMonthlyGoalId), eq(memberId)))
-				.willReturn(monthlyGoal);
+		given(monthlyGoalQueryService.searchOptionalById(eq(relatedMonthlyGoalId), eq(memberId)))
+				.willReturn(Optional.of(monthlyGoal));
 		given(taskGroupRepository.save(any(TaskGroup.class))).willReturn(expected);
 
 		TaskGroup saved =
@@ -67,9 +68,6 @@ class TaskGroupServiceTest {
 				.usingRecursiveComparison()
 				.ignoringFields("id", "weeklyGoal", "createdAt", "modifiedAt")
 				.isEqualTo(expected);
-		then(monthlyGoalQueryService)
-				.should(times(1))
-				.searchByIdOrElseNull(eq(relatedMonthlyGoalId), eq(memberId));
 		then(taskGroupRepository).should(times(1)).save(any(TaskGroup.class));
 	}
 }

--- a/src/test/java/com/sillim/recordit/task/service/TaskQueryServiceTest.java
+++ b/src/test/java/com/sillim/recordit/task/service/TaskQueryServiceTest.java
@@ -6,9 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 
 import com.sillim.recordit.calendar.domain.Calendar;
 import com.sillim.recordit.calendar.fixture.CalendarFixture;
@@ -73,10 +71,9 @@ class TaskQueryServiceTest {
 				.willReturn(calendar);
 		given(taskRepository.findAllByCalendarIdAndDate(calendarId, date)).willReturn(tasks);
 
-		taskQueryService.searchAllByDate(calendarId, date, memberId);
+		List<Task> found = taskQueryService.searchAllByDate(calendarId, date, memberId);
 
-		then(calendarService).should(times(1)).searchByCalendarId(eq(calendarId), eq(memberId));
-		then(taskRepository).should(times(1)).findAllByCalendarIdAndDate(eq(calendarId), eq(date));
+		assertThat(found).hasSize(tasks.size());
 	}
 
 	@Test
@@ -111,8 +108,6 @@ class TaskQueryServiceTest {
 					assertThat(taskDto.relatedMonthlyGoal()).isNull();
 					assertThat(taskDto.relatedWeeklyGoal()).isNull();
 				});
-		then(calendarService).should(times(1)).searchByCalendarId(eq(calendarId), eq(memberId));
-		then(taskRepository).should(times(1)).findByIdAndCalendarId(eq(taskId), eq(calendarId));
 	}
 
 	@Test
@@ -160,9 +155,6 @@ class TaskQueryServiceTest {
 					assertThat(taskDto.repetition().repetitionEndDate())
 							.isEqualTo(repetitionPattern.getRepetitionEndDate());
 				});
-		then(calendarService).should(times(1)).searchByCalendarId(eq(calendarId), eq(memberId));
-		then(taskRepository).should(times(1)).findByIdAndCalendarId(eq(taskId), eq(calendarId));
-		then(repetitionPatternService).should(times(1)).searchByTaskGroupId(eq(taskGroupId));
 	}
 
 	@Test
@@ -203,8 +195,6 @@ class TaskQueryServiceTest {
 							.isEqualTo(monthlyGoal.getTitle());
 					assertThat(taskDto.relatedWeeklyGoal()).isNull();
 				});
-		then(calendarService).should(times(1)).searchByCalendarId(eq(calendarId), eq(memberId));
-		then(taskRepository).should(times(1)).findByIdAndCalendarId(eq(taskId), eq(calendarId));
 	}
 
 	@Test
@@ -221,13 +211,8 @@ class TaskQueryServiceTest {
 		given(taskRepository.findByIdAndCalendarId(anyLong(), anyLong()))
 				.willThrow(new RecordNotFoundException(ErrorCode.TASK_NOT_FOUND));
 
-		assertThatCode(
-						() -> {
-							taskQueryService.searchByIdAndCalendarId(taskId, calendarId, memberId);
-						})
+		assertThatCode(() -> taskQueryService.searchByIdAndCalendarId(taskId, calendarId, memberId))
 				.isInstanceOf(RecordNotFoundException.class)
 				.hasMessage(ErrorCode.TASK_NOT_FOUND.getDescription());
-		then(calendarService).should(times(1)).searchByCalendarId(eq(calendarId), eq(memberId));
-		then(taskRepository).should(times(1)).findByIdAndCalendarId(eq(taskId), eq(calendarId));
 	}
 }


### PR DESCRIPTION
## 이슈 번호 (#114)

## 요약
- `relatedMonthlyGoalId`가 null일 때 발생하는 예외 처리
- null 대신 `Optional` 반환하도록 수정
- 테스트 코드 리팩토링


