### PR TITLE
🚑️ hotfix[#122]: alarmTimes field가 null로 반환되는 현상 수정

### DIFF
--- a/src/main/java/com/sillim/recordit/schedule/dto/response/DayScheduleResponse.java
+++ b/src/main/java/com/sillim/recordit/schedule/dto/response/DayScheduleResponse.java
@@ -42,6 +42,7 @@ public record DayScheduleResponse(
 				.latitude(schedule.getLatitude())
 				.longitude(schedule.getLongitude())
 				.setAlarm(schedule.getSetAlarm())
+				.alarmTimes(alarmTimes)
 				.isRepeated(isRepeated)
 				.calendarTitle(schedule.getCalendar().getTitle())
 				.repetitionPattern(repetitionPatternResponse)


### PR DESCRIPTION
## 이슈 번호 (#122)

## 요약
alarmTimes field가 null로 반환되는 현상 수정

## 변경 내용

