### PR TITLE
Feature 180: 주간 목표 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/sillim/recordit/goal/controller/WeeklyGoalController.java
+++ b/src/main/java/com/sillim/recordit/goal/controller/WeeklyGoalController.java
@@ -1,6 +1,7 @@
 package com.sillim.recordit.goal.controller;
 
 import com.sillim.recordit.config.security.authenticate.CurrentMember;
+import com.sillim.recordit.goal.domain.WeeklyGoal;
 import com.sillim.recordit.goal.dto.request.WeeklyGoalUpdateRequest;
 import com.sillim.recordit.goal.dto.response.WeeklyGoalListResponse;
 import com.sillim.recordit.goal.service.WeeklyGoalQueryService;
@@ -8,6 +9,8 @@ import com.sillim.recordit.goal.service.WeeklyGoalUpdateService;
 import com.sillim.recordit.member.domain.Member;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -22,6 +25,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/goals/weeks")
 public class WeeklyGoalController {
+
+	private static final int FIST_WEEK = 1;
 
 	private final WeeklyGoalUpdateService weeklyGoalUpdateService;
 	private final WeeklyGoalQueryService weeklyGoalQueryService;
@@ -41,9 +46,28 @@ public class WeeklyGoalController {
 			@RequestParam final Integer month,
 			@CurrentMember final Member member) {
 
-		return ResponseEntity.ok()
-				.body(
-						weeklyGoalQueryService.searchAllWeeklyGoalByDate(
-								year, month, member.getId()));
+		List<WeeklyGoal> weeklyGoals =
+				weeklyGoalQueryService.searchAllWeeklyGoalByDate(year, month, member.getId());
+
+		Map<Integer, List<WeeklyGoal>> goalsByWeek =
+				weeklyGoals.stream()
+						.collect(
+								Collectors.groupingBy(
+										weeklyGoal ->
+												changeWeekIfMonthOfStartDateIsNotEqual(
+														weeklyGoal, month)));
+
+		return ResponseEntity.ok(
+				goalsByWeek.entrySet().stream()
+						.map(e -> WeeklyGoalListResponse.of(e.getKey(), e.getValue()))
+						.toList());
+	}
+
+	private Integer changeWeekIfMonthOfStartDateIsNotEqual(
+			final WeeklyGoal weeklyGoal, final Integer currentMonth) {
+		if (weeklyGoal.getStartDate().getMonthValue() == currentMonth) {
+			return weeklyGoal.getWeek();
+		}
+		return FIST_WEEK;
 	}
 }

--- a/src/main/java/com/sillim/recordit/goal/controller/WeeklyGoalController.java
+++ b/src/main/java/com/sillim/recordit/goal/controller/WeeklyGoalController.java
@@ -2,15 +2,20 @@ package com.sillim.recordit.goal.controller;
 
 import com.sillim.recordit.config.security.authenticate.CurrentMember;
 import com.sillim.recordit.goal.dto.request.WeeklyGoalUpdateRequest;
+import com.sillim.recordit.goal.dto.response.WeeklyGoalListResponse;
+import com.sillim.recordit.goal.service.WeeklyGoalQueryService;
 import com.sillim.recordit.goal.service.WeeklyGoalUpdateService;
 import com.sillim.recordit.member.domain.Member;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,12 +24,26 @@ import org.springframework.web.bind.annotation.RestController;
 public class WeeklyGoalController {
 
 	private final WeeklyGoalUpdateService weeklyGoalUpdateService;
+	private final WeeklyGoalQueryService weeklyGoalQueryService;
 
 	@PostMapping
 	public ResponseEntity<Void> addWeeklyGoal(
-			@RequestBody @Validated WeeklyGoalUpdateRequest request, @CurrentMember Member member) {
+			@RequestBody @Validated final WeeklyGoalUpdateRequest request,
+			@CurrentMember final Member member) {
 
 		Long weeklyGoalId = weeklyGoalUpdateService.addWeeklyGoal(request, member.getId());
 		return ResponseEntity.created(URI.create("/api/v1/goals/weeks/" + weeklyGoalId)).build();
+	}
+
+	@GetMapping
+	public ResponseEntity<List<WeeklyGoalListResponse>> getWeeklyGoalList(
+			@RequestParam final Integer year,
+			@RequestParam final Integer month,
+			@CurrentMember final Member member) {
+
+		return ResponseEntity.ok()
+				.body(
+						weeklyGoalQueryService.searchAllWeeklyGoalByDate(
+								year, month, member.getId()));
 	}
 }

--- a/src/main/java/com/sillim/recordit/goal/domain/WeeklyGoal.java
+++ b/src/main/java/com/sillim/recordit/goal/domain/WeeklyGoal.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,6 +48,10 @@ public class WeeklyGoal extends BaseTime {
 	private boolean achieved;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "monthly_goal_id")
+	private MonthlyGoal relatedMonthlyGoal;
+
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
 
@@ -62,35 +67,16 @@ public class WeeklyGoal extends BaseTime {
 			final LocalDate startDate,
 			final LocalDate endDate,
 			final String colorHex,
+			final MonthlyGoal relatedMonthlyGoal,
 			final Member member) {
 		this.title = new GoalTitle(title);
 		this.description = new GoalDescription(description);
 		this.period = new WeeklyGoalPeriod(week, startDate, endDate);
 		this.colorHex = new GoalColorHex(colorHex);
 		this.achieved = false;
+		this.relatedMonthlyGoal = relatedMonthlyGoal;
 		this.member = member;
 		this.deleted = false;
-	}
-
-	public void modify(
-			final String newTitle,
-			final String newDescription,
-			final Integer week,
-			final LocalDate newStartDate,
-			final LocalDate newEndDate,
-			final String newColorHex) {
-		this.title = new GoalTitle(newTitle);
-		this.description = new GoalDescription(newDescription);
-		this.period = new WeeklyGoalPeriod(week, newStartDate, newEndDate);
-		this.colorHex = new GoalColorHex(newColorHex);
-	}
-
-	public void changeAchieveStatus(final Boolean status) {
-		this.achieved = status;
-	}
-
-	public boolean isOwnedBy(Long memberId) {
-		return member.equalsId(memberId);
 	}
 
 	public String getTitle() {
@@ -99,6 +85,10 @@ public class WeeklyGoal extends BaseTime {
 
 	public String getDescription() {
 		return description.getDescription();
+	}
+
+	public Integer getWeek() {
+		return period.getWeek();
 	}
 
 	public LocalDate getStartDate() {
@@ -111,5 +101,9 @@ public class WeeklyGoal extends BaseTime {
 
 	public String getColorHex() {
 		return colorHex.getColorHex();
+	}
+
+	public Optional<MonthlyGoal> getRelatedMonthlyGoal() {
+		return Optional.ofNullable(relatedMonthlyGoal);
 	}
 }

--- a/src/main/java/com/sillim/recordit/goal/dto/request/WeeklyGoalUpdateRequest.java
+++ b/src/main/java/com/sillim/recordit/goal/dto/request/WeeklyGoalUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.sillim.recordit.goal.dto.request;
 
 import com.sillim.recordit.global.validation.common.ColorHexValid;
+import com.sillim.recordit.goal.domain.MonthlyGoal;
 import com.sillim.recordit.goal.domain.WeeklyGoal;
 import com.sillim.recordit.member.domain.Member;
 import jakarta.validation.constraints.NotBlank;
@@ -15,7 +16,8 @@ public record WeeklyGoalUpdateRequest(
 		@NotNull @Range(min = 1, max = 6) Integer week,
 		@NotNull LocalDate startDate,
 		@NotNull LocalDate endDate,
-		@ColorHexValid String colorHex) {
+		@ColorHexValid String colorHex,
+		Long relatedMonthlyGoalId) {
 
 	public WeeklyGoal toEntity(final Member member) {
 
@@ -26,6 +28,20 @@ public record WeeklyGoalUpdateRequest(
 				.startDate(startDate)
 				.endDate(endDate)
 				.colorHex(colorHex)
+				.member(member)
+				.build();
+	}
+
+	public WeeklyGoal toEntity(final MonthlyGoal relatedMonthlyGoal, final Member member) {
+
+		return WeeklyGoal.builder()
+				.title(title)
+				.description(description)
+				.week(week)
+				.startDate(startDate)
+				.endDate(endDate)
+				.colorHex(colorHex)
+				.relatedMonthlyGoal(relatedMonthlyGoal)
 				.member(member)
 				.build();
 	}

--- a/src/main/java/com/sillim/recordit/goal/dto/response/RelatedMonthlyGoalResponse.java
+++ b/src/main/java/com/sillim/recordit/goal/dto/response/RelatedMonthlyGoalResponse.java
@@ -1,0 +1,15 @@
+package com.sillim.recordit.goal.dto.response;
+
+import com.sillim.recordit.goal.domain.MonthlyGoal;
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+
+public record RelatedMonthlyGoalResponse(Long id, String title) {
+
+	public static RelatedMonthlyGoalResponse from(MonthlyGoal monthlyGoal) {
+		return new RelatedMonthlyGoalResponse(monthlyGoal.getId(), monthlyGoal.getTitle());
+	}
+
+	public static RelatedMonthlyGoalResponse from(WeeklyGoal weeklyGoal) {
+		return new RelatedMonthlyGoalResponse(weeklyGoal.getId(), weeklyGoal.getTitle());
+	}
+}

--- a/src/main/java/com/sillim/recordit/goal/dto/response/WeeklyGoalListResponse.java
+++ b/src/main/java/com/sillim/recordit/goal/dto/response/WeeklyGoalListResponse.java
@@ -1,0 +1,13 @@
+package com.sillim.recordit.goal.dto.response;
+
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import java.util.List;
+
+public record WeeklyGoalListResponse(Integer week, List<WeeklyGoalResponse> weeklyGoals) {
+
+	public static WeeklyGoalListResponse from(Integer week, List<WeeklyGoal> weeklyGoals) {
+
+		return new WeeklyGoalListResponse(
+				week, weeklyGoals.stream().map(WeeklyGoalResponse::from).toList());
+	}
+}

--- a/src/main/java/com/sillim/recordit/goal/dto/response/WeeklyGoalListResponse.java
+++ b/src/main/java/com/sillim/recordit/goal/dto/response/WeeklyGoalListResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public record WeeklyGoalListResponse(Integer week, List<WeeklyGoalResponse> weeklyGoals) {
 
-	public static WeeklyGoalListResponse from(Integer week, List<WeeklyGoal> weeklyGoals) {
+	public static WeeklyGoalListResponse of(Integer week, List<WeeklyGoal> weeklyGoals) {
 
 		return new WeeklyGoalListResponse(
 				week, weeklyGoals.stream().map(WeeklyGoalResponse::from).toList());

--- a/src/main/java/com/sillim/recordit/goal/dto/response/WeeklyGoalResponse.java
+++ b/src/main/java/com/sillim/recordit/goal/dto/response/WeeklyGoalResponse.java
@@ -1,0 +1,20 @@
+package com.sillim.recordit.goal.dto.response;
+
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+
+public record WeeklyGoalResponse(
+		Long id, String title, Boolean achieved, RelatedMonthlyGoalResponse relatedMonthlyGoal) {
+
+	public static WeeklyGoalResponse from(final WeeklyGoal weeklyGoal) {
+
+		if (weeklyGoal.getRelatedMonthlyGoal().isEmpty()) {
+			return new WeeklyGoalResponse(
+					weeklyGoal.getId(), weeklyGoal.getTitle(), weeklyGoal.isAchieved(), null);
+		}
+		return new WeeklyGoalResponse(
+				weeklyGoal.getId(),
+				weeklyGoal.getTitle(),
+				weeklyGoal.isAchieved(),
+				RelatedMonthlyGoalResponse.from(weeklyGoal.getRelatedMonthlyGoal().get()));
+	}
+}

--- a/src/main/java/com/sillim/recordit/goal/repository/CustomWeeklyGoalRepository.java
+++ b/src/main/java/com/sillim/recordit/goal/repository/CustomWeeklyGoalRepository.java
@@ -1,0 +1,9 @@
+package com.sillim.recordit.goal.repository;
+
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import java.util.List;
+
+public interface CustomWeeklyGoalRepository {
+
+	List<WeeklyGoal> findWeeklyGoalInMonth(Integer year, Integer month, Long memberId);
+}

--- a/src/main/java/com/sillim/recordit/goal/repository/CustomWeeklyGoalRepositoryImpl.java
+++ b/src/main/java/com/sillim/recordit/goal/repository/CustomWeeklyGoalRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.sillim.recordit.goal.repository;
+
+import static com.sillim.recordit.goal.domain.QWeeklyGoal.weeklyGoal;
+
+import com.sillim.recordit.global.querydsl.QuerydslRepositorySupport;
+import com.sillim.recordit.goal.domain.MonthlyGoal;
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CustomWeeklyGoalRepositoryImpl extends QuerydslRepositorySupport
+		implements CustomWeeklyGoalRepository {
+
+	public CustomWeeklyGoalRepositoryImpl() {
+		super(MonthlyGoal.class);
+	}
+
+	@Override
+	public List<WeeklyGoal> findWeeklyGoalInMonth(Integer year, Integer month, Long memberId) {
+		return selectFrom(weeklyGoal)
+				.leftJoin(weeklyGoal.relatedMonthlyGoal)
+				.fetchJoin()
+				.where(
+						weeklyGoal
+								.member
+								.id
+								.eq(memberId)
+								.and(weeklyGoal.period.startDate.year().eq(year))
+								.and(weeklyGoal.period.startDate.month().eq(month)))
+				.fetch();
+	}
+}

--- a/src/main/java/com/sillim/recordit/goal/repository/CustomWeeklyGoalRepositoryImpl.java
+++ b/src/main/java/com/sillim/recordit/goal/repository/CustomWeeklyGoalRepositoryImpl.java
@@ -26,8 +26,20 @@ public class CustomWeeklyGoalRepositoryImpl extends QuerydslRepositorySupport
 								.member
 								.id
 								.eq(memberId)
-								.and(weeklyGoal.period.startDate.year().eq(year))
-								.and(weeklyGoal.period.startDate.month().eq(month)))
+								.and(
+										weeklyGoal
+												.period
+												.startDate
+												.year()
+												.eq(year)
+												.and(weeklyGoal.period.startDate.month().eq(month)))
+								.or(
+										weeklyGoal
+												.period
+												.endDate
+												.year()
+												.eq(year)
+												.and(weeklyGoal.period.endDate.month().eq(month))))
 				.fetch();
 	}
 }

--- a/src/main/java/com/sillim/recordit/goal/repository/WeeklyGoalRepository.java
+++ b/src/main/java/com/sillim/recordit/goal/repository/WeeklyGoalRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface WeeklyGoalRepository extends JpaRepository<WeeklyGoal, Long> {}
+public interface WeeklyGoalRepository
+		extends JpaRepository<WeeklyGoal, Long>, CustomWeeklyGoalRepository {}

--- a/src/main/java/com/sillim/recordit/goal/service/WeeklyGoalQueryService.java
+++ b/src/main/java/com/sillim/recordit/goal/service/WeeklyGoalQueryService.java
@@ -1,0 +1,33 @@
+package com.sillim.recordit.goal.service;
+
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import com.sillim.recordit.goal.dto.response.WeeklyGoalListResponse;
+import com.sillim.recordit.goal.repository.WeeklyGoalRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WeeklyGoalQueryService {
+
+	private final WeeklyGoalRepository weeklyGoalRepository;
+
+	public List<WeeklyGoalListResponse> searchAllWeeklyGoalByDate(
+			final Integer year, final Integer month, final Long memberId) {
+
+		List<WeeklyGoal> weeklyGoals =
+				weeklyGoalRepository.findWeeklyGoalInMonth(year, month, memberId);
+
+		Map<Integer, List<WeeklyGoal>> goalsByWeek =
+				weeklyGoals.stream().collect(Collectors.groupingBy(WeeklyGoal::getWeek));
+
+		return goalsByWeek.entrySet().stream()
+				.map(e -> WeeklyGoalListResponse.from(e.getKey(), e.getValue()))
+				.toList();
+	}
+}

--- a/src/main/java/com/sillim/recordit/goal/service/WeeklyGoalQueryService.java
+++ b/src/main/java/com/sillim/recordit/goal/service/WeeklyGoalQueryService.java
@@ -1,11 +1,8 @@
 package com.sillim.recordit.goal.service;
 
 import com.sillim.recordit.goal.domain.WeeklyGoal;
-import com.sillim.recordit.goal.dto.response.WeeklyGoalListResponse;
 import com.sillim.recordit.goal.repository.WeeklyGoalRepository;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,17 +14,9 @@ public class WeeklyGoalQueryService {
 
 	private final WeeklyGoalRepository weeklyGoalRepository;
 
-	public List<WeeklyGoalListResponse> searchAllWeeklyGoalByDate(
+	public List<WeeklyGoal> searchAllWeeklyGoalByDate(
 			final Integer year, final Integer month, final Long memberId) {
 
-		List<WeeklyGoal> weeklyGoals =
-				weeklyGoalRepository.findWeeklyGoalInMonth(year, month, memberId);
-
-		Map<Integer, List<WeeklyGoal>> goalsByWeek =
-				weeklyGoals.stream().collect(Collectors.groupingBy(WeeklyGoal::getWeek));
-
-		return goalsByWeek.entrySet().stream()
-				.map(e -> WeeklyGoalListResponse.from(e.getKey(), e.getValue()))
-				.toList();
+		return weeklyGoalRepository.findWeeklyGoalInMonth(year, month, memberId);
 	}
 }

--- a/src/test/java/com/sillim/recordit/goal/controller/WeeklyGoalControllerTest.java
+++ b/src/test/java/com/sillim/recordit/goal/controller/WeeklyGoalControllerTest.java
@@ -2,16 +2,32 @@ package com.sillim.recordit.goal.controller;
 
 import static com.sillim.recordit.support.restdocs.ApiDocumentUtils.getDocumentRequest;
 import static com.sillim.recordit.support.restdocs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.sillim.recordit.goal.domain.WeeklyGoal;
 import com.sillim.recordit.goal.dto.request.WeeklyGoalUpdateRequest;
+import com.sillim.recordit.goal.fixture.WeeklyGoalFixture;
+import com.sillim.recordit.goal.service.WeeklyGoalQueryService;
 import com.sillim.recordit.goal.service.WeeklyGoalUpdateService;
+import com.sillim.recordit.member.domain.Member;
+import com.sillim.recordit.member.fixture.MemberFixture;
 import com.sillim.recordit.support.restdocs.RestDocsTest;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -23,10 +39,18 @@ import org.springframework.test.web.servlet.ResultActions;
 public class WeeklyGoalControllerTest extends RestDocsTest {
 
 	@MockBean WeeklyGoalUpdateService weeklyGoalUpdateService;
+	@MockBean WeeklyGoalQueryService weeklyGoalQueryService;
+
+	private Member member;
+
+	@BeforeEach
+	void beforeEach() {
+		member = MemberFixture.DEFAULT.getMember();
+	}
 
 	@Test
 	@DisplayName("새로운 주 목표를 추가한다.")
-	void monthlyGoalAddTest() throws Exception {
+	void weeklyGoalAddTest() throws Exception {
 
 		WeeklyGoalUpdateRequest request =
 				new WeeklyGoalUpdateRequest(
@@ -35,7 +59,8 @@ public class WeeklyGoalControllerTest extends RestDocsTest {
 						3,
 						LocalDate.of(2024, 8, 11),
 						LocalDate.of(2024, 8, 17),
-						"ff83c8ef");
+						"ff83c8ef",
+						1L);
 
 		ResultActions perform =
 				mockMvc.perform(
@@ -53,5 +78,95 @@ public class WeeklyGoalControllerTest extends RestDocsTest {
 								getDocumentRequest(),
 								getDocumentResponse(),
 								requestHeaders(authorizationDesc())));
+	}
+
+	@Test
+	@DisplayName("당월의 주 목표 목록을 조회한다.")
+	void weeklyGoalList() throws Exception {
+
+		WeeklyGoal expected = WeeklyGoalFixture.DEFAULT.getWithMember(member);
+
+		List<WeeklyGoal> weeklyGoals =
+				LongStream.rangeClosed(1, 3)
+						.mapToObj(
+								(id) -> {
+									WeeklyGoal goal =
+											spy(WeeklyGoalFixture.DEFAULT.getWithMember(member));
+									given(goal.getId()).willReturn(id);
+									given(goal.isAchieved()).willReturn(id % 2 == 0);
+									return goal;
+								})
+						.toList();
+
+		given(weeklyGoalQueryService.searchAllWeeklyGoalByDate(anyInt(), anyInt(), any()))
+				.willReturn(weeklyGoals);
+
+		ResultActions perform =
+				mockMvc.perform(
+						get("/api/v1/goals/weeks")
+								.headers(authorizationHeader())
+								.queryParam("year", "2024")
+								.queryParam("month", "8"));
+
+		perform.andExpect(status().isOk())
+				.andExpect(jsonPath("$.size()").value(1))
+				.andExpect(jsonPath("$.[0].week").value(expected.getWeek()))
+				.andExpect(jsonPath("$.[0].weeklyGoals.size()").value(3))
+				.andExpect(jsonPath("$.[0].weeklyGoals[0].id").value(1))
+				.andExpect(jsonPath("$.[0].weeklyGoals[0].title").value(expected.getTitle()))
+				.andExpect(jsonPath("$.[0].weeklyGoals[0].achieved").value(false))
+				.andExpect(jsonPath("$.[0].weeklyGoals[1].id").value(2))
+				.andExpect(jsonPath("$.[0].weeklyGoals[1].title").value(expected.getTitle()))
+				.andExpect(jsonPath("$.[0].weeklyGoals[1].achieved").value(true))
+				.andExpect(jsonPath("$.[0].weeklyGoals[2].id").value(3))
+				.andExpect(jsonPath("$.[0].weeklyGoals[2].title").value(expected.getTitle()))
+				.andExpect(jsonPath("$.[0].weeklyGoals[2].achieved").value(false));
+
+		perform.andDo(print())
+				.andDo(
+						document(
+								"weekly-goal-list",
+								getDocumentRequest(),
+								getDocumentResponse(),
+								requestHeaders(authorizationDesc()),
+								queryParameters(
+										parameterWithName("year").description("조회할 연도"),
+										parameterWithName("month").description("조회할 월"))));
+	}
+
+	@Test
+	@DisplayName("두 개월에 걸쳐있는 주 목표가 있는 경우, 두번째 월로 검색했을 때 해당 주 목표를 첫 주차로 반환한다.")
+	void weeklyGoalListWhenStuckInTwoMonths() throws Exception {
+
+		Integer expectedWeek = 1;
+		List<WeeklyGoal> weeklyGoals =
+				List.of(
+						WeeklyGoalFixture.DEFAULT.getWithWeekAndStartDateAndEndDate(
+								5, LocalDate.of(2024, 9, 29), LocalDate.of(2024, 10, 5), member));
+
+		given(weeklyGoalQueryService.searchAllWeeklyGoalByDate(anyInt(), anyInt(), any()))
+				.willReturn(weeklyGoals);
+
+		ResultActions perform =
+				mockMvc.perform(
+						get("/api/v1/goals/weeks")
+								.headers(authorizationHeader())
+								.queryParam("year", "2024")
+								.queryParam("month", "8"));
+
+		perform.andExpect(status().isOk())
+				.andExpect(jsonPath("$.size()").value(1))
+				.andExpect(jsonPath("$.[0].week").value(expectedWeek));
+
+		perform.andDo(print())
+				.andDo(
+						document(
+								"weekly-goal-list-when-stuck-in-two-months",
+								getDocumentRequest(),
+								getDocumentResponse(),
+								requestHeaders(authorizationDesc()),
+								queryParameters(
+										parameterWithName("year").description("조회할 연도"),
+										parameterWithName("month").description("조회할 월"))));
 	}
 }

--- a/src/test/java/com/sillim/recordit/goal/fixture/WeeklyGoalFixture.java
+++ b/src/test/java/com/sillim/recordit/goal/fixture/WeeklyGoalFixture.java
@@ -1,0 +1,71 @@
+package com.sillim.recordit.goal.fixture;
+
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import com.sillim.recordit.member.domain.Member;
+import java.time.LocalDate;
+
+public enum WeeklyGoalFixture {
+	DEFAULT(
+			"데이터베이스 3장까지",
+			"다 할 때까지 숨 참는다!",
+			3,
+			LocalDate.of(2024, 8, 11),
+			LocalDate.of(2024, 8, 17),
+			"ff83c8ef"),
+	MODIFIED(
+			"(수정)데이터베이스 3장까지",
+			"(수정)다 할 때까지 숨 참는다!",
+			4,
+			LocalDate.of(2024, 8, 18),
+			LocalDate.of(2024, 8, 24),
+			"ff123456");
+
+	private final String title;
+	private final String description;
+	private final Integer week;
+	private final LocalDate startDate;
+	private final LocalDate endDate;
+	private final String colorHex;
+
+	WeeklyGoalFixture(
+			String title,
+			String description,
+			Integer week,
+			LocalDate startDate,
+			LocalDate endDate,
+			String colorHex) {
+		this.title = title;
+		this.description = description;
+		this.week = week;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.colorHex = colorHex;
+	}
+
+	public WeeklyGoal getWithMember(Member member) {
+
+		return WeeklyGoal.builder()
+				.title(title)
+				.description(description)
+				.week(week)
+				.startDate(startDate)
+				.endDate(endDate)
+				.colorHex(colorHex)
+				.member(member)
+				.build();
+	}
+
+	public WeeklyGoal getWithWeekAndStartDateAndEndDate(
+			Integer week, LocalDate startDate, LocalDate endDate, Member member) {
+
+		return WeeklyGoal.builder()
+				.title(title)
+				.description(description)
+				.week(week)
+				.startDate(startDate)
+				.endDate(endDate)
+				.colorHex(colorHex)
+				.member(member)
+				.build();
+	}
+}

--- a/src/test/java/com/sillim/recordit/goal/repository/WeeklyGoalRepositoryTest.java
+++ b/src/test/java/com/sillim/recordit/goal/repository/WeeklyGoalRepositoryTest.java
@@ -1,0 +1,117 @@
+package com.sillim.recordit.goal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import com.sillim.recordit.goal.fixture.WeeklyGoalFixture;
+import com.sillim.recordit.member.domain.Member;
+import com.sillim.recordit.member.fixture.MemberFixture;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@DataJpaTest
+public class WeeklyGoalRepositoryTest {
+
+	@Autowired WeeklyGoalRepository weeklyGoalRepository;
+	@Autowired TestEntityManager em;
+
+	private Member member;
+
+	@BeforeEach
+	void beforeEach() {
+		member = MemberFixture.DEFAULT.getMember();
+		em.persist(member);
+	}
+
+	@Test
+	@DisplayName("새로운 주 목표 레코드를 저장한다.")
+	void save() {
+		// given
+		final WeeklyGoal expected = WeeklyGoalFixture.DEFAULT.getWithMember(member);
+		// when
+		WeeklyGoal saved =
+				weeklyGoalRepository.save(WeeklyGoalFixture.DEFAULT.getWithMember(member));
+
+		// then
+		// 자동 생성 필드가 null이 아닌지 검증
+		assertThat(saved.getId()).isNotNull();
+		assertThat(saved.getCreatedAt()).isNotNull();
+		assertThat(saved.getModifiedAt()).isNotNull();
+
+		assertThat(saved)
+				.usingRecursiveComparison()
+				.ignoringFields("id", "member", "createdAt", "modifiedAt")
+				.isEqualTo(expected);
+		assertThat(saved.getMember()).usingRecursiveComparison().isEqualTo(expected.getMember());
+	}
+
+	@Test
+	@DisplayName("해당 년, 월에 해당하는 주 목표 목록을 조회한다.")
+	void findByGoalYearAndGoalMonthAndMember() {
+		// given
+		final Integer expectedYear = 2024;
+		final Integer expectedMonth = 8;
+		weeklyGoalRepository.saveAll(
+				List.of(
+						WeeklyGoalFixture.DEFAULT.getWithWeekAndStartDateAndEndDate(
+								2, LocalDate.of(2024, 8, 4), LocalDate.of(2024, 8, 10), member),
+						WeeklyGoalFixture.DEFAULT.getWithWeekAndStartDateAndEndDate(
+								5, LocalDate.of(2024, 8, 25), LocalDate.of(2024, 8, 31), member),
+						WeeklyGoalFixture.DEFAULT.getWithWeekAndStartDateAndEndDate(
+								1, LocalDate.of(2024, 9, 1), LocalDate.of(2024, 9, 7), member)));
+		// when
+		List<WeeklyGoal> foundList =
+				weeklyGoalRepository.findWeeklyGoalInMonth(
+						expectedYear, expectedMonth, member.getId());
+		// then
+		assertThat(foundList).hasSize(2);
+		for (WeeklyGoal found : foundList) {
+			Assertions.assertAll(
+					() -> {
+						assertThat(found.getStartDate().getYear()).isEqualTo(expectedYear);
+						assertThat(found.getStartDate().getMonthValue()).isEqualTo(expectedMonth);
+						assertThat(found.getEndDate().getYear()).isEqualTo(expectedYear);
+						assertThat(found.getEndDate().getMonthValue()).isEqualTo(expectedMonth);
+					});
+		}
+	}
+
+	@Test
+	@DisplayName("해당 년, 월에 해당하는 주 목표 목록을 조회한다. - 두 개월에 걸쳐 존재하는 주 목표도 함께 조회된다.")
+	void findByGoalYearAndGoalMonthAndMemberWhenStuckInTwoMonths() {
+		// given
+		final Integer expectedYear = 2024;
+		final Integer expectedMonth = 8;
+		weeklyGoalRepository.saveAll(
+				List.of(
+						WeeklyGoalFixture.DEFAULT.getWithWeekAndStartDateAndEndDate(
+								5, LocalDate.of(2024, 7, 28), LocalDate.of(2024, 8, 3), member),
+						WeeklyGoalFixture.DEFAULT.getWithWeekAndStartDateAndEndDate(
+								1, LocalDate.of(2024, 9, 1), LocalDate.of(2024, 9, 7), member)));
+		// when
+		List<WeeklyGoal> foundList =
+				weeklyGoalRepository.findWeeklyGoalInMonth(
+						expectedYear, expectedMonth, member.getId());
+		// then
+		assertThat(foundList).hasSize(1);
+		for (WeeklyGoal found : foundList) {
+			Assertions.assertAll(
+					() -> {
+						assertThat(found.getStartDate().getYear()).isEqualTo(expectedYear);
+						assertThat(found.getStartDate().getMonthValue())
+								.isNotEqualTo(expectedMonth);
+						assertThat(found.getEndDate().getYear()).isEqualTo(expectedYear);
+						assertThat(found.getEndDate().getMonthValue()).isEqualTo(expectedMonth);
+					});
+		}
+	}
+}

--- a/src/test/java/com/sillim/recordit/goal/service/WeeklyGoalQueryServiceTest.java
+++ b/src/test/java/com/sillim/recordit/goal/service/WeeklyGoalQueryServiceTest.java
@@ -1,0 +1,67 @@
+package com.sillim.recordit.goal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import com.sillim.recordit.goal.fixture.WeeklyGoalFixture;
+import com.sillim.recordit.goal.repository.WeeklyGoalRepository;
+import com.sillim.recordit.member.domain.Member;
+import com.sillim.recordit.member.fixture.MemberFixture;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class WeeklyGoalQueryServiceTest {
+
+	@Mock WeeklyGoalRepository weeklyGoalRepository;
+	@InjectMocks WeeklyGoalQueryService weeklyGoalQueryService;
+
+	private Member member;
+
+	@BeforeEach
+	void beforeEach() {
+		member = MemberFixture.DEFAULT.getMember();
+	}
+
+	@Test
+	@DisplayName("startDate와 endDate를 기반으로 해당 주 목표들을 조회한다.")
+	void searchAllWeeklyGoalByDate() {
+		Long memberId = 1L;
+		Integer year = 2024;
+		Integer month = 8;
+		List<WeeklyGoal> weeklyGoals =
+				LongStream.rangeClosed(1, 3)
+						.mapToObj(
+								(id) ->
+										WeeklyGoalFixture.DEFAULT.getWithWeekAndStartDateAndEndDate(
+												3,
+												LocalDate.of(2024, 8, 11),
+												LocalDate.of(2024, 8, 17),
+												member))
+						.toList();
+		given(weeklyGoalRepository.findWeeklyGoalInMonth(eq(year), eq(month), eq(memberId)))
+				.willReturn(weeklyGoals);
+
+		List<WeeklyGoal> found =
+				weeklyGoalQueryService.searchAllWeeklyGoalByDate(year, month, memberId);
+
+		assertAll(
+				() -> {
+					assertThat(found).hasSize(weeklyGoals.size());
+					found.forEach(wg -> assertThat(wg.getStartDate()).hasYear(year));
+					found.forEach(wg -> assertThat(wg.getStartDate()).hasMonth(Month.of(month)));
+				});
+	}
+}

--- a/src/test/java/com/sillim/recordit/goal/service/WeeklyGoalUpdateServiceTest.java
+++ b/src/test/java/com/sillim/recordit/goal/service/WeeklyGoalUpdateServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+import com.sillim.recordit.goal.domain.MonthlyGoal;
 import com.sillim.recordit.goal.domain.WeeklyGoal;
 import com.sillim.recordit.goal.dto.request.WeeklyGoalUpdateRequest;
 import com.sillim.recordit.goal.repository.WeeklyGoalRepository;
@@ -26,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class WeeklyGoalUpdateServiceTest {
 
+	@Mock MonthlyGoalQueryService monthlyGoalQueryService;
 	@Mock MemberQueryService memberQueryService;
 	@Mock WeeklyGoalRepository weeklyGoalRepository;
 	@InjectMocks WeeklyGoalUpdateService weeklyGoalUpdateService;
@@ -37,10 +39,10 @@ public class WeeklyGoalUpdateServiceTest {
 	}
 
 	@Test
-	@DisplayName("새로운 월 목표를 추가한다.")
-	void addTest() {
+	@DisplayName("새로운 주 목표를 추가한다. - 연관 월 목표 없음")
+	void addWeeklyGoalWithoutRelatedMonthlyGoal() {
 		Long memberId = 1L;
-		Long monthlyGoalId = 2L;
+		Long weeklyGoalId = 2L;
 		WeeklyGoalUpdateRequest request =
 				new WeeklyGoalUpdateRequest(
 						"취뽀하기!",
@@ -48,15 +50,44 @@ public class WeeklyGoalUpdateServiceTest {
 						3,
 						LocalDate.of(2024, 8, 11),
 						LocalDate.of(2024, 8, 17),
-						"ff83c8ef");
+						"ff83c8ef",
+						null);
 		WeeklyGoal saved = mock(WeeklyGoal.class);
 		given(memberQueryService.findByMemberId(eq(memberId))).willReturn(member);
 		given(weeklyGoalRepository.save(any(WeeklyGoal.class))).willReturn(saved);
-		given(saved.getId()).willReturn(monthlyGoalId);
+		given(saved.getId()).willReturn(weeklyGoalId);
 
 		Long savedId = weeklyGoalUpdateService.addWeeklyGoal(request, memberId);
 
-		assertThat(savedId).isEqualTo(monthlyGoalId);
+		assertThat(savedId).isEqualTo(weeklyGoalId);
+		then(weeklyGoalRepository).should(times(1)).save(any(WeeklyGoal.class));
+	}
+
+	@Test
+	@DisplayName("새로운 주 목표를 추가한다. - 연관 월 목표 있음")
+	void addWeeklyGoalWithRelatedMonthlyGoal() {
+		Long memberId = 1L;
+		Long weeklyGoalId = 2L;
+		Long relatedMonthlyGoalId = 3L;
+		WeeklyGoalUpdateRequest request =
+				new WeeklyGoalUpdateRequest(
+						"취뽀하기!",
+						"취업할 때까지 숨 참는다.",
+						3,
+						LocalDate.of(2024, 8, 11),
+						LocalDate.of(2024, 8, 17),
+						"ff83c8ef",
+						relatedMonthlyGoalId);
+		WeeklyGoal saved = mock(WeeklyGoal.class);
+		given(memberQueryService.findByMemberId(eq(memberId))).willReturn(member);
+		given(monthlyGoalQueryService.searchByIdAndCheckAuthority(relatedMonthlyGoalId, memberId))
+				.willReturn(mock(MonthlyGoal.class));
+		given(weeklyGoalRepository.save(any(WeeklyGoal.class))).willReturn(saved);
+		given(saved.getId()).willReturn(weeklyGoalId);
+
+		Long savedId = weeklyGoalUpdateService.addWeeklyGoal(request, memberId);
+
+		assertThat(savedId).isEqualTo(weeklyGoalId);
 		then(weeklyGoalRepository).should(times(1)).save(any(WeeklyGoal.class));
 	}
 }


### PR DESCRIPTION
## 이슈 번호 (#180)

## 요약
- 주간 목표 목록 조회 기능 구현
- 주간 목표 목록 조회 기능 테스트

## 주 목표의 `startDate`, `endDate`가 두 개월 사이에 존재하는 경우
- 2024.07.28 - 2024.08.3에 해당하는 주 목표 (DB에는 7월 5주차로 저장)
- 2024년 7월의 주 목표 목록 조회, 2024년 8월의 주 목표 목록 조회 시 모두 보여야 함
- 2024년 8월의 주 목표 목록 조회 시, 해당 주 목표를 8월 1주차로 반환하도록 예외 처리

