### PR TITLE
Feature 197: 할 일 연관 목표 연결 기능 구현

### DIFF
--- a/src/main/java/com/sillim/recordit/goal/controller/GoalController.java
+++ b/src/main/java/com/sillim/recordit/goal/controller/GoalController.java
@@ -1,0 +1,38 @@
+package com.sillim.recordit.goal.controller;
+
+import com.sillim.recordit.config.security.authenticate.CurrentMember;
+import com.sillim.recordit.goal.domain.MonthlyGoal;
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import com.sillim.recordit.goal.dto.response.GoalListResponse;
+import com.sillim.recordit.goal.service.MonthlyGoalQueryService;
+import com.sillim.recordit.goal.service.WeeklyGoalQueryService;
+import com.sillim.recordit.member.domain.Member;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/goals")
+public class GoalController {
+
+	private final MonthlyGoalQueryService monthlyGoalQueryService;
+	private final WeeklyGoalQueryService weeklyGoalQueryService;
+
+	@GetMapping
+	public ResponseEntity<GoalListResponse> getGoalListByDate(
+			@RequestParam final Integer year,
+			@RequestParam final Integer month,
+			@CurrentMember final Member member) {
+
+		List<MonthlyGoal> monthlyGoals =
+				monthlyGoalQueryService.searchAllByDate(year, month, member.getId());
+		List<WeeklyGoal> weeklyGoals =
+				weeklyGoalQueryService.searchAllWeeklyGoalByDate(year, month, member.getId());
+		return ResponseEntity.ok(GoalListResponse.of(monthlyGoals, weeklyGoals));
+	}
+}

--- a/src/main/java/com/sillim/recordit/goal/dto/response/GoalListResponse.java
+++ b/src/main/java/com/sillim/recordit/goal/dto/response/GoalListResponse.java
@@ -1,0 +1,17 @@
+package com.sillim.recordit.goal.dto.response;
+
+import com.sillim.recordit.goal.domain.MonthlyGoal;
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import java.util.List;
+
+public record GoalListResponse(List<GoalResponse> monthlyGoals, List<GoalResponse> weeklyGoals) {
+
+	public static GoalListResponse of(
+			final List<MonthlyGoal> monthlyGoals, final List<WeeklyGoal> weeklyGoals) {
+		List<GoalResponse> monthlyGoalResponses =
+				monthlyGoals.stream().map(GoalResponse::from).toList();
+		List<GoalResponse> weeklyGoalResponses =
+				weeklyGoals.stream().map(GoalResponse::from).toList();
+		return new GoalListResponse(monthlyGoalResponses, weeklyGoalResponses);
+	}
+}

--- a/src/main/java/com/sillim/recordit/goal/dto/response/GoalResponse.java
+++ b/src/main/java/com/sillim/recordit/goal/dto/response/GoalResponse.java
@@ -1,0 +1,15 @@
+package com.sillim.recordit.goal.dto.response;
+
+import com.sillim.recordit.goal.domain.MonthlyGoal;
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+
+public record GoalResponse(Long id, String title) {
+
+	public static GoalResponse from(final MonthlyGoal monthlyGoal) {
+		return new GoalResponse(monthlyGoal.getId(), monthlyGoal.getTitle());
+	}
+
+	public static GoalResponse from(final WeeklyGoal weeklyGoal) {
+		return new GoalResponse(weeklyGoal.getId(), weeklyGoal.getTitle());
+	}
+}

--- a/src/main/java/com/sillim/recordit/task/service/TaskGroupService.java
+++ b/src/main/java/com/sillim/recordit/task/service/TaskGroupService.java
@@ -6,6 +6,7 @@ import com.sillim.recordit.goal.domain.MonthlyGoal;
 import com.sillim.recordit.goal.domain.WeeklyGoal;
 import com.sillim.recordit.goal.dto.RelatedGoals;
 import com.sillim.recordit.goal.service.MonthlyGoalQueryService;
+import com.sillim.recordit.goal.service.WeeklyGoalQueryService;
 import com.sillim.recordit.task.domain.TaskGroup;
 import com.sillim.recordit.task.domain.repetition.TaskRepetitionPatternFactory;
 import com.sillim.recordit.task.dto.request.TaskGroupUpdateRequest;
@@ -21,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TaskGroupService {
 
 	private final MonthlyGoalQueryService monthlyGoalQueryService;
-	// TODO: WeeklyGoal 기능 구현 후 추가 필요
+	private final WeeklyGoalQueryService weeklyGoalQueryService;
 
 	private final TaskGroupRepository taskGroupRepository;
 
@@ -137,7 +138,8 @@ public class TaskGroupService {
 			return RelatedGoals.empty();
 		}
 		if (monthlyGoalId == null) {
-			WeeklyGoal weeklyGoal = null;
+			WeeklyGoal weeklyGoal =
+					weeklyGoalQueryService.searchByIdAndCheckAuthority(weeklyGoalId, memberId);
 			return RelatedGoals.from(weeklyGoal);
 		}
 		if (weeklyGoalId == null) {
@@ -147,7 +149,8 @@ public class TaskGroupService {
 		}
 		MonthlyGoal monthlyGoal =
 				monthlyGoalQueryService.searchByIdAndCheckAuthority(monthlyGoalId, memberId);
-		WeeklyGoal weeklyGoal = null;
+		WeeklyGoal weeklyGoal =
+				weeklyGoalQueryService.searchByIdAndCheckAuthority(weeklyGoalId, memberId);
 		return RelatedGoals.of(monthlyGoal, weeklyGoal);
 	}
 }

--- a/src/test/java/com/sillim/recordit/goal/controller/GoalControllerTest.java
+++ b/src/test/java/com/sillim/recordit/goal/controller/GoalControllerTest.java
@@ -1,0 +1,111 @@
+package com.sillim.recordit.goal.controller;
+
+import static com.sillim.recordit.support.restdocs.ApiDocumentUtils.getDocumentRequest;
+import static com.sillim.recordit.support.restdocs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sillim.recordit.goal.domain.MonthlyGoal;
+import com.sillim.recordit.goal.domain.WeeklyGoal;
+import com.sillim.recordit.goal.fixture.MonthlyGoalFixture;
+import com.sillim.recordit.goal.fixture.WeeklyGoalFixture;
+import com.sillim.recordit.goal.service.MonthlyGoalQueryService;
+import com.sillim.recordit.goal.service.WeeklyGoalQueryService;
+import com.sillim.recordit.member.domain.Member;
+import com.sillim.recordit.member.fixture.MemberFixture;
+import com.sillim.recordit.support.restdocs.RestDocsTest;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(GoalController.class)
+public class GoalControllerTest extends RestDocsTest {
+
+	@MockBean MonthlyGoalQueryService monthlyGoalQueryService;
+	@MockBean WeeklyGoalQueryService weeklyGoalQueryService;
+
+	private Member member;
+
+	@BeforeEach
+	void beforeEach() {
+		member = MemberFixture.DEFAULT.getMember();
+	}
+
+	@Test
+	@DisplayName("당월의 목표 목록을 조회한다.")
+	void monthlyGoalListTest() throws Exception {
+		List<MonthlyGoal> monthlyGoals =
+				LongStream.rangeClosed(1, 3)
+						.mapToObj(
+								(id) -> {
+									MonthlyGoal goal =
+											spy(MonthlyGoalFixture.DEFAULT.getWithMember(member));
+									given(goal.getId()).willReturn(id);
+									given(goal.isAchieved()).willReturn(id % 2 == 0);
+									return goal;
+								})
+						.toList();
+		given(monthlyGoalQueryService.searchAllByDate(anyInt(), anyInt(), any()))
+				.willReturn(monthlyGoals);
+		List<WeeklyGoal> weeklyGoals =
+				LongStream.rangeClosed(1, 2)
+						.mapToObj(
+								(id) -> {
+									WeeklyGoal goal =
+											spy(WeeklyGoalFixture.DEFAULT.getWithMember(member));
+									given(goal.getId()).willReturn(id);
+									given(goal.isAchieved()).willReturn(id % 2 == 0);
+									return goal;
+								})
+						.toList();
+		given(weeklyGoalQueryService.searchAllWeeklyGoalByDate(anyInt(), anyInt(), any()))
+				.willReturn(weeklyGoals);
+
+		ResultActions perform =
+				mockMvc.perform(
+						get("/api/v1/goals")
+								.headers(authorizationHeader())
+								.queryParam("year", "2024")
+								.queryParam("month", "4"));
+
+		perform.andExpect(status().isOk())
+				.andExpect(jsonPath("$.monthlyGoals.size()").value(3))
+				.andExpect(jsonPath("$.weeklyGoals.size()").value(2))
+				.andExpect(jsonPath("$.monthlyGoals.[0].id").value(1))
+				.andExpect(jsonPath("$.monthlyGoals.[0].title").value("취뽀하기!"))
+				.andExpect(jsonPath("$.monthlyGoals.[1].id").value(2))
+				.andExpect(jsonPath("$.monthlyGoals.[1].title").value("취뽀하기!"))
+				.andExpect(jsonPath("$.monthlyGoals.[2].id").value(3))
+				.andExpect(jsonPath("$.monthlyGoals.[2].title").value("취뽀하기!"))
+				.andExpect(jsonPath("$.weeklyGoals.[0].id").value(1))
+				.andExpect(jsonPath("$.weeklyGoals.[0].title").value("데이터베이스 3장까지"))
+				.andExpect(jsonPath("$.weeklyGoals.[1].id").value(2))
+				.andExpect(jsonPath("$.weeklyGoals.[1].title").value("데이터베이스 3장까지"));
+
+		perform.andDo(print())
+				.andDo(
+						document(
+								"goal-list",
+								getDocumentRequest(),
+								getDocumentResponse(),
+								requestHeaders(authorizationDesc()),
+								queryParameters(
+										parameterWithName("year").description("조회할 연도"),
+										parameterWithName("month").description("조회할 월"))));
+	}
+}

--- a/src/test/java/com/sillim/recordit/task/service/TaskGroupServiceTest.java
+++ b/src/test/java/com/sillim/recordit/task/service/TaskGroupServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import com.sillim.recordit.goal.domain.MonthlyGoal;
 import com.sillim.recordit.goal.domain.WeeklyGoal;
 import com.sillim.recordit.goal.service.MonthlyGoalQueryService;
+import com.sillim.recordit.goal.service.WeeklyGoalQueryService;
 import com.sillim.recordit.task.domain.TaskGroup;
 import com.sillim.recordit.task.domain.TaskRepetitionType;
 import com.sillim.recordit.task.domain.repetition.TaskRepetitionPattern;
@@ -34,6 +35,7 @@ class TaskGroupServiceTest {
 	@InjectMocks TaskGroupService taskGroupService;
 	@Mock TaskGroupRepository taskGroupRepository;
 	@Mock MonthlyGoalQueryService monthlyGoalQueryService;
+	@Mock WeeklyGoalQueryService weeklyGoalQueryService;
 
 	// TODO: WeeklyGoal 기능 구현 후 테스트 추가 필요
 


### PR DESCRIPTION
## 이슈 번호 (#197)

## 요약
할 일과 연관 목표 연결을 위해
- 할 일을 생성하고자 하는 날짜의 목표 목록 조회 기능 구현
- 할 일 그룹 생성/수정 시 연관 주 목표를 조회 기능 연동
