### PR TITLE
feature[#214]: 자신의 피드 댓글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/sillim/recordit/feed/repository/CustomFeedCommentRepository.java
+++ b/src/main/java/com/sillim/recordit/feed/repository/CustomFeedCommentRepository.java
@@ -9,5 +9,7 @@ public interface CustomFeedCommentRepository {
 
 	Slice<FeedComment> findPaginatedOrderByCreatedAtAsc(Pageable pageable, Long feedId);
 
+	Slice<FeedComment> findByMemberIdOrderByCreatedAtAsc(Pageable pageable, Long memberId);
+
 	Optional<FeedComment> findByIdWithFetch(Long commentId);
 }

--- a/src/main/java/com/sillim/recordit/feed/repository/CustomFeedCommentRepositoryImpl.java
+++ b/src/main/java/com/sillim/recordit/feed/repository/CustomFeedCommentRepositoryImpl.java
@@ -36,6 +36,22 @@ public class CustomFeedCommentRepositoryImpl extends QuerydslRepositorySupport
 	}
 
 	@Override
+	public Slice<FeedComment> findByMemberIdOrderByCreatedAtAsc(Pageable pageable, Long memberId) {
+		List<FeedComment> feedComments =
+				selectFrom(feedComment)
+						.leftJoin(feedComment.member)
+						.fetchJoin()
+						.where(feedComment.deleted.isFalse())
+						.where(feedComment.member.id.eq(memberId))
+						.orderBy(feedComment.createdAt.asc())
+						.offset(pageable.getOffset())
+						.limit(pageable.getPageSize() + 1)
+						.fetch();
+
+		return new SliceImpl<>(feedComments, pageable, hasNext(pageable, feedComments));
+	}
+
+	@Override
 	public Optional<FeedComment> findByIdWithFetch(Long commentId) {
 		return Optional.ofNullable(
 				selectFrom(feedComment)

--- a/src/main/java/com/sillim/recordit/feed/service/FeedCommentQueryService.java
+++ b/src/main/java/com/sillim/recordit/feed/service/FeedCommentQueryService.java
@@ -46,4 +46,20 @@ public class FeedCommentQueryService {
 						pageable,
 						feedCommentSlice.hasNext()));
 	}
+
+	public SliceResponse<FeedCommentInListResponse> searchByMemberIdOldCreated(
+			Pageable pageable, Long memberId) {
+		Slice<FeedComment> feedCommentSlice =
+				feedCommentRepository.findByMemberIdOrderByCreatedAtAsc(pageable, memberId);
+		return SliceResponse.of(
+				new SliceImpl<>(
+						feedCommentSlice.stream()
+								.map(
+										feedComment ->
+												FeedCommentInListResponse.from(
+														feedComment, memberId))
+								.toList(),
+						pageable,
+						feedCommentSlice.hasNext()));
+	}
 }

--- a/src/main/java/com/sillim/recordit/member/controller/MemberController.java
+++ b/src/main/java/com/sillim/recordit/member/controller/MemberController.java
@@ -1,12 +1,16 @@
 package com.sillim.recordit.member.controller;
 
 import com.sillim.recordit.config.security.authenticate.CurrentMember;
+import com.sillim.recordit.feed.dto.response.FeedCommentInListResponse;
+import com.sillim.recordit.feed.service.FeedCommentQueryService;
+import com.sillim.recordit.global.dto.response.SliceResponse;
 import com.sillim.recordit.member.domain.Member;
 import com.sillim.recordit.member.dto.request.ProfileModifyRequest;
 import com.sillim.recordit.member.dto.response.ProfileResponse;
 import com.sillim.recordit.member.service.MemberCommandService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,10 +20,18 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
 	private final MemberCommandService memberCommandService;
+	private final FeedCommentQueryService feedCommentQueryService;
 
 	@GetMapping("/me")
 	public ResponseEntity<ProfileResponse> profileDetails(@CurrentMember Member member) {
 		return ResponseEntity.ok(ProfileResponse.of(member));
+	}
+
+	@GetMapping("/me/comments")
+	public ResponseEntity<SliceResponse<FeedCommentInListResponse>> myCommentList(
+			Pageable pageable, @CurrentMember Member member) {
+		return ResponseEntity.ok(
+				feedCommentQueryService.searchByMemberIdOldCreated(pageable, member.getId()));
 	}
 
 	@PutMapping("/me")

--- a/src/test/java/com/sillim/recordit/feed/repository/CustomFeedCommentRepositoryTest.java
+++ b/src/test/java/com/sillim/recordit/feed/repository/CustomFeedCommentRepositoryTest.java
@@ -65,4 +65,31 @@ class CustomFeedCommentRepositoryTest {
 					assertThat(foundFeedComments2.isLast()).isTrue();
 				});
 	}
+
+	@Test
+	@DisplayName("특정 멤버의 피드 댓글을 pagination해서 created 오름차순으로 조회한다.")
+	void findPaginatedByMemberIdOrderByCreatedDesc() {
+		List<FeedComment> feedComments =
+				IntStream.range(0, 10)
+						.mapToObj(i -> em.persist(new FeedComment("content", feed, member)))
+						.toList();
+
+		Slice<FeedComment> foundFeedComments1 =
+				customFeedCommentRepository.findByMemberIdOrderByCreatedAtAsc(
+						PageRequest.of(0, 5), member.getId());
+
+		Slice<FeedComment> foundFeedComments2 =
+				customFeedCommentRepository.findByMemberIdOrderByCreatedAtAsc(
+						PageRequest.of(3, 3), member.getId());
+
+		assertAll(
+				() -> {
+					assertThat(foundFeedComments1).hasSize(5);
+					assertThat(foundFeedComments1.isLast()).isFalse();
+					assertThat(foundFeedComments1.getContent().get(0).getId())
+							.isEqualTo(feedComments.get(0).getId());
+					assertThat(foundFeedComments2).hasSize(1);
+					assertThat(foundFeedComments2.isLast()).isTrue();
+				});
+	}
 }

--- a/src/test/java/com/sillim/recordit/feed/service/FeedCommentQueryServiceTest.java
+++ b/src/test/java/com/sillim/recordit/feed/service/FeedCommentQueryServiceTest.java
@@ -53,4 +53,28 @@ class FeedCommentQueryServiceTest {
 					assertThat(feedComments.isLast()).isTrue();
 				});
 	}
+
+	@Test
+	@DisplayName("오래된 순으로 pagination해서 특정 멤버의 피드 댓글 목록을 조회할 수 있다.")
+	void searchFeedCommentsPaginatedByMemberIdOrderByRecentCreated() {
+		PageRequest pageRequest = PageRequest.of(1, 10);
+		Member member = mock(Member.class);
+		Feed feed = FeedFixture.DEFAULT.getFeed(member);
+		FeedComment feedComment = spy(new FeedComment("content", feed, member));
+		long memberId = 1L;
+		given(feedComment.getId()).willReturn(1L);
+		given(
+						feedCommentRepository.findByMemberIdOrderByCreatedAtAsc(
+								eq(pageRequest), eq(memberId)))
+				.willReturn(new SliceImpl<>(List.of(feedComment), pageRequest, false));
+
+		SliceResponse<FeedCommentInListResponse> feedComments =
+				feedCommentQueryService.searchByMemberIdOldCreated(pageRequest, memberId);
+
+		assertAll(
+				() -> {
+					assertThat(feedComments.content()).hasSize(1);
+					assertThat(feedComments.isLast()).isTrue();
+				});
+	}
 }

--- a/src/test/java/com/sillim/recordit/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/sillim/recordit/member/controller/MemberControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.sillim.recordit.feed.service.FeedCommentQueryService;
 import com.sillim.recordit.member.dto.request.ProfileModifyRequest;
 import com.sillim.recordit.member.service.MemberCommandService;
 import com.sillim.recordit.support.restdocs.RestDocsTest;
@@ -22,6 +23,7 @@ import org.springframework.test.web.servlet.ResultActions;
 class MemberControllerTest extends RestDocsTest {
 
 	@MockBean MemberCommandService memberCommandService;
+	@MockBean FeedCommentQueryService feedCommentQueryService;
 
 	@Test
 	@DisplayName("자신의 정보를 조회한다.")
@@ -48,5 +50,16 @@ class MemberControllerTest extends RestDocsTest {
 
 		perform.andDo(print())
 				.andDo(document("profile-modify", getDocumentRequest(), getDocumentResponse()));
+	}
+
+	@Test
+	@DisplayName("자신의 피드 댓글들을 조회한다.")
+	void myFeedComments() throws Exception {
+		ResultActions perform = mockMvc.perform(get("/api/v1/members/me/comments"));
+
+		perform.andExpect(status().isOk());
+
+		perform.andDo(print())
+				.andDo(document("my-feed-comments", getDocumentRequest(), getDocumentResponse()));
 	}
 }


### PR DESCRIPTION
## 이슈 번호 (#214)

## 요약
자신의 피드 댓글 목록 조회 기능 구현

## 변경 내용
MemberController에 자신의 피드 댓글 조회 메서드 추가

