### PR TITLE
fix[#233]: 캘린더 생성 시 캘린더 멤버에 들어가지 않는 문제 수정

### DIFF
--- a/src/main/java/com/sillim/recordit/calendar/controller/CalendarController.java
+++ b/src/main/java/com/sillim/recordit/calendar/controller/CalendarController.java
@@ -8,7 +8,6 @@ import com.sillim.recordit.calendar.dto.response.CalendarMemberResponse;
 import com.sillim.recordit.calendar.dto.response.CalendarResponse;
 import com.sillim.recordit.calendar.service.CalendarCommandService;
 import com.sillim.recordit.calendar.service.CalendarMemberService;
-import com.sillim.recordit.calendar.service.CalendarQueryService;
 import com.sillim.recordit.calendar.service.JoinCalendarService;
 import com.sillim.recordit.config.security.authenticate.CurrentMember;
 import com.sillim.recordit.member.domain.Member;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CalendarController {
 
-	private final CalendarQueryService calendarQueryService;
 	private final CalendarCommandService calendarCommandService;
 	private final CalendarMemberService calendarMemberService;
 	private final JoinCalendarService joinCalendarService;
@@ -41,6 +39,7 @@ public class CalendarController {
 	public ResponseEntity<CalendarResponse> addCalendar(
 			@RequestBody @Valid CalendarAddRequest request, @CurrentMember Member member) {
 		Calendar calendar = calendarCommandService.addCalendar(request, member.getId());
+		calendarMemberService.addCalendarMember(calendar.getId(), member.getId());
 		return ResponseEntity.created(URI.create("/api/v1/calendars/" + calendar.getId()))
 				.body(CalendarResponse.from(calendar));
 	}

--- a/src/test/java/com/sillim/recordit/calendar/controller/CalendarControllerTest.java
+++ b/src/test/java/com/sillim/recordit/calendar/controller/CalendarControllerTest.java
@@ -19,7 +19,6 @@ import com.sillim.recordit.calendar.dto.request.JoinInCalendarRequest;
 import com.sillim.recordit.calendar.fixture.CalendarFixture;
 import com.sillim.recordit.calendar.service.CalendarCommandService;
 import com.sillim.recordit.calendar.service.CalendarMemberService;
-import com.sillim.recordit.calendar.service.CalendarQueryService;
 import com.sillim.recordit.calendar.service.JoinCalendarService;
 import com.sillim.recordit.member.domain.Auth;
 import com.sillim.recordit.member.domain.Member;
@@ -39,7 +38,6 @@ import org.springframework.test.web.servlet.ResultActions;
 class CalendarControllerTest extends RestDocsTest {
 
 	@MockBean CalendarCommandService calendarCommandService;
-	@MockBean CalendarQueryService calendarQueryService;
 	@MockBean CalendarMemberService calendarMemberService;
 	@MockBean JoinCalendarService joinCalendarService;
 
@@ -61,7 +59,7 @@ class CalendarControllerTest extends RestDocsTest {
 	@DisplayName("캘린더 목록을 조회한다.")
 	void calendarList() throws Exception {
 		Calendar calendar = CalendarFixture.DEFAULT.getCalendar(member);
-		given(calendarQueryService.searchByMemberId(any())).willReturn(List.of(calendar));
+		given(calendarMemberService.searchCalendarsByMemberId(any())).willReturn(List.of(calendar));
 
 		ResultActions perform = mockMvc.perform(get("/api/v1/calendars"));
 


### PR DESCRIPTION
## 이슈 번호 (#233)

## 요약
캘린더 생성 시 캘린더 멤버에 들어가지 않는 문제 수정

## 변경 내용
CalendarController에 CalendarMember 생성 코드 추가
