### PR TITLE
hotfix[#245]: 캘린더 삭제 시 캘린더 멤버 연관관계로 인해 삭제되지 않는 현상 수정

### DIFF
--- a/src/main/java/com/sillim/recordit/calendar/domain/Calendar.java
+++ b/src/main/java/com/sillim/recordit/calendar/domain/Calendar.java
@@ -5,6 +5,8 @@ import com.sillim.recordit.global.exception.ErrorCode;
 import com.sillim.recordit.global.exception.common.InvalidRequestException;
 import com.sillim.recordit.member.domain.Member;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,6 +31,13 @@ public class Calendar {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
+
+	@OneToMany(
+			mappedBy = "calendar",
+			fetch = FetchType.LAZY,
+			cascade = CascadeType.REMOVE,
+			orphanRemoval = true)
+	private List<CalendarMember> calendarMembers = new ArrayList<>();
 
 	@Builder
 	public Calendar(String title, Member member, CalendarCategory category) {

--- a/src/main/java/com/sillim/recordit/calendar/domain/CalendarMember.java
+++ b/src/main/java/com/sillim/recordit/calendar/domain/CalendarMember.java
@@ -34,6 +34,17 @@ public class CalendarMember extends BaseTime {
 
 	public CalendarMember(Member member, Calendar calendar) {
 		this.member = member;
+		setCalendar(calendar);
+	}
+
+	private void setCalendar(Calendar calendar) {
+		if (this.calendar != null) {
+			this.calendar.getCalendarMembers().remove(this);
+		}
+
 		this.calendar = calendar;
+		if (calendar != null) {
+			calendar.getCalendarMembers().add(this);
+		}
 	}
 }

--- a/src/test/java/com/sillim/recordit/calendar/domain/CalendarMemberTest.java
+++ b/src/test/java/com/sillim/recordit/calendar/domain/CalendarMemberTest.java
@@ -1,0 +1,33 @@
+package com.sillim.recordit.calendar.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sillim.recordit.calendar.fixture.CalendarCategoryFixture;
+import com.sillim.recordit.calendar.fixture.CalendarFixture;
+import com.sillim.recordit.member.domain.Member;
+import com.sillim.recordit.member.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CalendarMemberTest {
+
+	@Test
+	@DisplayName("캘린더 멤버 저장 시 캘린더에 연관관계 리스트로 저장된다.")
+	void saveRelatedEntityInCalendarWhenSaveCalendarMember() {
+		Member member = MemberFixture.DEFAULT.getMember();
+		CalendarCategory category = CalendarCategoryFixture.DEFAULT.getCalendarCategory(member);
+		Calendar calendar = CalendarFixture.DEFAULT.getCalendar(member, category);
+		CalendarMember calendarMember = new CalendarMember(member, calendar);
+
+		assertThat(calendar.getCalendarMembers()).contains(calendarMember);
+	}
+
+	@Test
+	@DisplayName("캘린더 멤버에 캘린더를 null로 저장할 수 있다.")
+	void test() {
+		Member member = MemberFixture.DEFAULT.getMember();
+		CalendarMember calendarMember = new CalendarMember(member, null);
+
+		assertThat(calendarMember.getCalendar()).isNull();
+	}
+}


### PR DESCRIPTION
## 이슈 번호 (#245)

## 요약
캘린더 삭제 시 캘린더 멤버 연관관계로 인해 삭제되지 않는 현상 수정
