### PR TITLE
fix[#269]: 한 디바이스에서 여러 계정의 FCM 토큰이 등록될 수 있도록 수정

### DIFF
--- a/src/main/java/com/sillim/recordit/member/controller/MemberController.java
+++ b/src/main/java/com/sillim/recordit/member/controller/MemberController.java
@@ -6,8 +6,10 @@ import com.sillim.recordit.feed.service.FeedCommentQueryService;
 import com.sillim.recordit.global.dto.response.SliceResponse;
 import com.sillim.recordit.member.domain.Member;
 import com.sillim.recordit.member.dto.request.ProfileModifyRequest;
+import com.sillim.recordit.member.dto.request.TokenUpdateRequest;
 import com.sillim.recordit.member.dto.response.ProfileResponse;
 import com.sillim.recordit.member.service.MemberCommandService;
+import com.sillim.recordit.member.service.MemberDeviceService;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class MemberController {
 
 	private final MemberCommandService memberCommandService;
 	private final FeedCommentQueryService feedCommentQueryService;
+	private final MemberDeviceService memberDeviceService;
 
 	@GetMapping("/me")
 	public ResponseEntity<ProfileResponse> profileDetails(@CurrentMember Member member) {
@@ -48,6 +51,14 @@ public class MemberController {
 	public ResponseEntity<Void> profileImageModify(
 			@RequestPart MultipartFile newImage, @CurrentMember Member member) throws IOException {
 		memberCommandService.modifyMemberProfileImage(newImage, member.getId());
+
+		return ResponseEntity.noContent().build();
+	}
+
+	@PutMapping("/me/fcmToken")
+	public ResponseEntity<Void> fcmTokenModify(
+			@RequestBody TokenUpdateRequest request, @CurrentMember Member member) {
+		memberDeviceService.updateFcmToken(request.deviceId(), request.fcmToken(), member.getId());
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/sillim/recordit/member/dto/request/TokenUpdateRequest.java
+++ b/src/main/java/com/sillim/recordit/member/dto/request/TokenUpdateRequest.java
@@ -1,0 +1,3 @@
+package com.sillim.recordit.member.dto.request;
+
+public record TokenUpdateRequest(String deviceId, String fcmToken) {}

--- a/src/main/java/com/sillim/recordit/member/repository/CustomMemberDeviceRepository.java
+++ b/src/main/java/com/sillim/recordit/member/repository/CustomMemberDeviceRepository.java
@@ -4,4 +4,6 @@ import java.util.List;
 
 public interface CustomMemberDeviceRepository {
 	List<String> findFcmTokensByMemberId(Long memberId);
+
+	void updateFcmToken(String deviceId, String fcmToken, Long memberId);
 }

--- a/src/main/java/com/sillim/recordit/member/repository/CustomMemberDeviceRepositoryImpl.java
+++ b/src/main/java/com/sillim/recordit/member/repository/CustomMemberDeviceRepositoryImpl.java
@@ -22,4 +22,13 @@ public class CustomMemberDeviceRepositoryImpl extends QuerydslRepositorySupport
 				.where(memberDevice.member.id.eq(memberId))
 				.fetch();
 	}
+
+	@Override
+	public void updateFcmToken(String deviceId, String fcmToken, Long memberId) {
+		update(memberDevice)
+				.set(memberDevice.fcmToken, fcmToken)
+				.where(memberDevice.identifier.eq(deviceId))
+				.where(memberDevice.member.id.eq(memberId))
+				.execute();
+	}
 }

--- a/src/main/java/com/sillim/recordit/member/repository/MemberDeviceRepository.java
+++ b/src/main/java/com/sillim/recordit/member/repository/MemberDeviceRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberDeviceRepository
 		extends JpaRepository<MemberDevice, Long>, CustomMemberDeviceRepository {
 
-	boolean existsByIdentifier(String identifier);
+	boolean existsByIdentifierAndMemberId(String identifier, Long memberId);
 
 	void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/sillim/recordit/member/service/MemberDeviceService.java
+++ b/src/main/java/com/sillim/recordit/member/service/MemberDeviceService.java
@@ -17,7 +17,7 @@ public class MemberDeviceService {
 
 	public void addMemberDeviceIfNotExists(
 			String id, String model, String fcmToken, Member member) {
-		if (!memberDeviceRepository.existsByIdentifier(id)) {
+		if (!memberDeviceRepository.existsByIdentifierAndMemberId(id, member.getId())) {
 			memberDeviceRepository.save(
 					MemberDevice.builder()
 							.identifier(id)
@@ -26,6 +26,10 @@ public class MemberDeviceService {
 							.member(member)
 							.build());
 		}
+	}
+
+	public void updateFcmToken(String deviceId, String fcmToken, Long memberId) {
+		memberDeviceRepository.updateFcmToken(deviceId, fcmToken, memberId);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/test/java/com/sillim/recordit/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/sillim/recordit/member/controller/MemberControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.sillim.recordit.feed.service.FeedCommentQueryService;
 import com.sillim.recordit.member.dto.request.ProfileModifyRequest;
 import com.sillim.recordit.member.service.MemberCommandService;
+import com.sillim.recordit.member.service.MemberDeviceService;
 import com.sillim.recordit.support.restdocs.RestDocsTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ class MemberControllerTest extends RestDocsTest {
 
 	@MockBean MemberCommandService memberCommandService;
 	@MockBean FeedCommentQueryService feedCommentQueryService;
+	@MockBean MemberDeviceService memberDeviceService;
 
 	@Test
 	@DisplayName("자신의 정보를 조회한다.")

--- a/src/test/java/com/sillim/recordit/member/service/MemberDeviceServiceTest.java
+++ b/src/test/java/com/sillim/recordit/member/service/MemberDeviceServiceTest.java
@@ -26,18 +26,22 @@ class MemberDeviceServiceTest {
 	@Test
 	@DisplayName("디바이스가 존재하지 않으면 추가할 수 있다.")
 	void addedMemberDeviceIfNotExists() {
-		given(memberDeviceRepository.existsByIdentifier(eq("id"))).willReturn(false);
+		given(memberDeviceRepository.existsByIdentifierAndMemberId(eq("id"), any()))
+				.willReturn(false);
 
 		memberDeviceService.addMemberDeviceIfNotExists(
 				"id", "model", "token", MemberFixture.DEFAULT.getMember());
 
-		then(memberDeviceRepository).should(times(1)).existsByIdentifier(eq("id"));
+		then(memberDeviceRepository)
+				.should(times(1))
+				.existsByIdentifierAndMemberId(eq("id"), any());
 	}
 
 	@Test
 	@DisplayName("디바이스가 존재하면 추가되지 않는다.")
 	void notAddedMemberDeviceIfExists() {
-		given(memberDeviceRepository.existsByIdentifier(eq("id"))).willReturn(true);
+		given(memberDeviceRepository.existsByIdentifierAndMemberId(eq("id"), any()))
+				.willReturn(true);
 
 		memberDeviceService.addMemberDeviceIfNotExists(
 				"id", "model", "token", MemberFixture.DEFAULT.getMember());


### PR DESCRIPTION
## 이슈 번호 (#269)

## 요약
한 디바이스에서 여러 계정의 FCM 토큰이 등록될 수 있도록 수정

