### PR TITLE
Authorization Header 부재 예외처리를 위한 EntryPoint 구현

### DIFF
--- a/src/main/java/com/sillim/recordit/config/security/SecurityConfig.java
+++ b/src/main/java/com/sillim/recordit/config/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.sillim.recordit.config.security;
 
 import com.sillim.recordit.config.security.filter.AuthExceptionTranslationFilter;
 import com.sillim.recordit.config.security.filter.JwtAuthenticationFilter;
+import com.sillim.recordit.config.security.handler.JwtAuthenticationEntryPoint;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +35,7 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 public class SecurityConfig {
 
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 	private final AuthExceptionTranslationFilter authExceptionTranslationFilter;
 	private final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService;
 	private final AuthenticationSuccessHandler successHandler;
@@ -76,6 +78,8 @@ public class SecurityConfig {
 				.sessionManagement(
 						configurer ->
 								configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.exceptionHandling(
+						config -> config.authenticationEntryPoint(jwtAuthenticationEntryPoint))
 				.addFilterBefore(
 						jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 				.addFilterBefore(authExceptionTranslationFilter, JwtAuthenticationFilter.class)

--- a/src/main/java/com/sillim/recordit/config/security/handler/AuthenticationExceptionHandler.java
+++ b/src/main/java/com/sillim/recordit/config/security/handler/AuthenticationExceptionHandler.java
@@ -2,6 +2,7 @@ package com.sillim.recordit.config.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sillim.recordit.global.dto.response.ErrorResponse;
+import com.sillim.recordit.global.exception.ErrorCode;
 import com.sillim.recordit.global.exception.common.ApplicationException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -11,6 +12,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -25,11 +29,23 @@ public class AuthenticationExceptionHandler {
 		if (response.isCommitted()) {
 			return;
 		}
+		ErrorResponse body = ErrorResponse.from(exception.getErrorCode());
+		writeUnauthorizedResponse(response, body);
+	}
 
-		log.info(
-				"Authentication Exception: {} {}",
-				exception.getErrorCode(),
-				exception.getMessage());
+	public void handle(HttpServletResponse response, AuthenticationException exception)
+			throws IOException {
+		if (response.isCommitted()) {
+			return;
+		}
+		ErrorResponse body = ErrorResponse.from(resolveErrorCode(exception));
+		writeUnauthorizedResponse(response, body);
+	}
+
+	private void writeUnauthorizedResponse(HttpServletResponse response, ErrorResponse body)
+			throws IOException {
+		log.info("Authentication Exception: {} {}", body.errorCode(), body.message());
+
 		response.setStatus(HttpStatus.UNAUTHORIZED.value());
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
@@ -37,8 +53,17 @@ public class AuthenticationExceptionHandler {
 		response.getWriter()
 				.write(
 						objectMapper.writeValueAsString(
-								ResponseEntity.status(HttpStatus.UNAUTHORIZED.value())
-										.body(ErrorResponse.from(exception.getErrorCode()))));
+								ResponseEntity.status(HttpStatus.UNAUTHORIZED.value()).body(body)));
 		response.getWriter().flush();
+	}
+
+	private ErrorCode resolveErrorCode(AuthenticationException e) {
+		log.debug("Implementation of AuthenticationException is {}", e.getClass().getSimpleName());
+		if (e instanceof AuthenticationCredentialsNotFoundException
+				|| e instanceof InsufficientAuthenticationException) {
+			return ErrorCode.AUTHENTICATION_REQUIRED;
+		} else {
+			return ErrorCode.AUTHENTICATION_FAILED;
+		}
 	}
 }

--- a/src/main/java/com/sillim/recordit/config/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sillim/recordit/config/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package com.sillim.recordit.config.security.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final AuthenticationExceptionHandler authenticationExceptionHandler;
+
+	@Override
+	public void commence(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			AuthenticationException authException)
+			throws IOException {
+
+		authenticationExceptionHandler.handle(response, authException);
+	}
+}


### PR DESCRIPTION
## 이슈 번호 (#310 )

## 요약
- Authorization 헤더가 없는 요청에 대한 예외처리를 위해 `AuthenticationEntryPoint` 구현

## 변경사항
- `AuthenticationExceptionHandler`에서 `AuthenticationException`을 처리할 수 있는 메서드 추가함