### PR TITLE
Infra 349: 새로운 GCP 계정으로 이전

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,12 @@ name: LetsRecordIt Server Deploy with Gradle
 
 on:
   pull_request:
-    branches:
-      - main
-    types:
-      - closed
+    branches: [ "develop" ]
+#  pull_request:
+#    branches:
+#      - main
+#    types:
+#      - closed
 
 jobs:
   setup-build-publish-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,12 +2,10 @@ name: LetsRecordIt Server Deploy with Gradle
 
 on:
   pull_request:
-    branches: [ "develop" ]
-#  pull_request:
-#    branches:
-#      - main
-#    types:
-#      - closed
+    branches:
+      - main
+    types:
+      - closed
 
 jobs:
   setup-build-publish-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,10 +77,10 @@ jobs:
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
           envs: GITHUB_SHA
           script: |
-            docker ps -q -f letsrecordit-server && docker stop letsrecordit-server && docker rm letsrecordit-server
-            docker images -q ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest && docker rmi ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest
-            docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest
-            sudo docker-compose up -d
+            sudo docker ps -q -f name=letsrecordit-server && sudo docker stop letsrecordit-server && sudo docker rm letsrecordit-server
+            sudo docker images -q ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest && sudo docker rmi ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest
+            sudo docker compose up -d
 
       - name: Health Check
         uses: appleboy/ssh-action@master
@@ -117,6 +117,6 @@ jobs:
             if [ -z "$HEALTH_CHECK_CONTAINER_NAME" ]; then
               echo "HEALTH_CHECK_CONTAINER_NAME not set, please add it on github actions secrets"
             else
-              docker logs --since "10m" "$HEALTH_CHECK_CONTAINER_NAME" 2>&1 || echo "Could not get logs for container: $HEALTH_CHECK_CONTAINER_NAME"
+              sudo docker logs --since "10m" "$HEALTH_CHECK_CONTAINER_NAME" 2>&1 || echo "Could not get logs for container: $HEALTH_CHECK_CONTAINER_NAME"
             fi
             exit 1

--- a/src/main/java/com/sillim/recordit/config/gcp/GCSConfig.java
+++ b/src/main/java/com/sillim/recordit/config/gcp/GCSConfig.java
@@ -1,30 +1,18 @@
 package com.sillim.recordit.config.gcp;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
-import java.io.InputStream;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.util.ResourceUtils;
 
 @Configuration
 @Profile("!test")
 public class GCSConfig {
 
-	@Value("${spring.cloud.gcp.storage.credentials.location}")
-	private String keyFileName;
-
 	@Bean
 	public Storage storage() throws IOException {
-		InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
-
-		return StorageOptions.newBuilder()
-				.setCredentials(GoogleCredentials.fromStream(keyFile))
-				.build()
-				.getService();
+		return StorageOptions.getDefaultInstance().getService();
 	}
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,7 +22,6 @@ spring:
   cloud:
     gcp:
       storage:
-        project-id: ${GCP_PROJECT_ID}
         bucket: ${GCP_BUCKET_NAME}
   security:
     oauth2:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,8 +22,6 @@ spring:
   cloud:
     gcp:
       storage:
-        credentials:
-          location: ${GCP_CREDENTIAL_LOCATION}
         project-id: ${GCP_PROJECT_ID}
         bucket: ${GCP_BUCKET_NAME}
   security:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,7 +19,6 @@ spring:
   cloud:
     gcp:
       storage:
-        project-id: ${GCP_PROJECT_ID}
         bucket: ${GCP_BUCKET_NAME}
   security:
     oauth2:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,8 +19,6 @@ spring:
   cloud:
     gcp:
       storage:
-        credentials:
-          location: ${GCP_CREDENTIAL_LOCATION}
         project-id: ${GCP_PROJECT_ID}
         bucket: ${GCP_BUCKET_NAME}
   security:


### PR DESCRIPTION
## 이슈 번호 (#349)

## 요약
- 새로운 GCP 계정으로 이전
- 클라우드 아키텍처 재구성 -> 기존 프로젝트 스크립트, 프로퍼티 수정

## 변경사항
### GCP ADC 사용 및 관리 포인트 제거
이전에는 애플리케이션 서버에 GCP Credential 파일을 포함해줘야 했음
- 세부적으로 권한 설정이 가능하다는 장점, 그러나 관리 포인트 증가 (파일 관리, 환경변수 세팅 등...)

**ADC**(Application Default Credentials)를 사용하면 그럴 필요 없음, GCP Project 내부에 있는 리소스(VM, Storage 등)는 자동으로 ADC를 Inject 받기 때문

Credential을 노출하지 않기 때문에 GCP 플랫폼을 사용할 때는 해당 방식을 사용하는 것이 보안적으로 좋아보임 ([Credential JSON 파일을 지양하라는 레퍼런스](https://stackoverflow.com/questions/79278556/how-to-properly-inject-service-account-credentials-in-google-cloud-build-for-clo))

``` yaml
# as-is
    gcp:
      storage:
        credentials:
          location: ${GCP_CREDENTIAL_LOCATION}
        project-id: ${GCP_PROJECT_ID}
        bucket: ${GCP_BUCKET_NAME}
# to-be
    gcp:
      storage:
        bucket: ${GCP_BUCKET_NAME}
```
``` java
// as-is
	@Bean
	public Storage storage() throws IOException {
		InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();

		return StorageOptions.newBuilder()
				.setCredentials(GoogleCredentials.fromStream(keyFile))
				.build()
				.getService();
	}
// to-be
	@Bean
	public Storage storage() throws IOException {
		return StorageOptions.getDefaultInstance().getService();
	}
```

**로컬에서 Storage에 대한 권한이 필요한 경우에는 `gcloud` 명령을 사용해 로그인해주면 됨**
```
gcloud auth login
```
